### PR TITLE
Move @types modules to dependencies and update comments

### DIFF
--- a/docs/Connect.html
+++ b/docs/Connect.html
@@ -422,7 +422,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -581,7 +581,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -791,7 +791,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -962,7 +962,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1272,7 +1272,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1423,13 +1423,13 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 |
 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -1452,7 +1452,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -1607,7 +1607,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1917,10 +1917,10 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 |
 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -2181,10 +2181,10 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -2362,7 +2362,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -2517,7 +2517,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -2782,7 +2782,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -2953,7 +2953,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3131,7 +3131,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -3286,7 +3286,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3309,7 +3309,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3464,7 +3464,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3487,7 +3487,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -3546,7 +3546,7 @@
 
     
 
-    <h4 class="name" id="isJSON"><span class="type-signature"></span>isJSON<span class="signature">()</span><span class="type-signature"> &rarr; {Boolean}</span></h4>
+    <h4 class="name" id="isJSON"><span class="type-signature"></span>isJSON<span class="signature">()</span><span class="type-signature"> &rarr; {boolean}</span></h4>
 
     
 
@@ -3638,7 +3638,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
     </dd>
@@ -3748,7 +3748,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -4009,10 +4009,10 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -4167,7 +4167,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -4190,7 +4190,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -4451,7 +4451,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -4602,7 +4602,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -4757,7 +4757,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -4780,7 +4780,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -5113,7 +5113,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -5419,7 +5419,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -5574,7 +5574,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -5729,7 +5729,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             

--- a/docs/Connect.js.html
+++ b/docs/Connect.js.html
@@ -73,8 +73,8 @@ const userAgents = {
 /**
  * Returns proxy url based on the proxy options.
  *
- * @param  {Object} proxy proxy options
- * @return {String} proxy url based on the options
+ * @param  {object} proxy proxy options
+ * @return {string} proxy url based on the options
  * @private
  */
 function makeProxyUrl(proxy) {
@@ -131,7 +131,7 @@ class Connect {
 	/**
 	 * Set the url for the connection.
 	 *
-	 * @param {String} url self-descriptive
+	 * @param {string} url self-descriptive
 	 * @return {Connect} self
 	 */
 	url(url) {
@@ -143,7 +143,7 @@ class Connect {
 	 * @static
 	 * Creates and returns a new Connect object with the given url.
 	 *
-	 * @param  {String} url self-descriptive
+	 * @param  {string} url self-descriptive
 	 * @return {Connect}    A new Connect object with url set to the given url
 	 */
 	static url(url) {
@@ -165,7 +165,7 @@ class Connect {
 	/**
 	 * Set or unset the followRedirect option for the connection.
 	 *
-	 * @param  {Boolean} shouldFollowRedirect boolean representing whether to follow redirect or not
+	 * @param  {boolean} shouldFollowRedirect boolean representing whether to follow redirect or not
 	 * @return {Connect}                      self
 	 */
 	followRedirect(shouldFollowRedirect) {
@@ -176,7 +176,7 @@ class Connect {
 	/**
 	 * Set value of a header parameter for the connection.
 	 *
-	 * @param  {String} headerName name of the header parameter whose value is to be set
+	 * @param  {string} headerName name of the header parameter whose value is to be set
 	 * @param  {*} headerValue     value to be set
 	 * @return {Connect}           self
 	 */
@@ -194,7 +194,7 @@ class Connect {
 	/**
 	 * Set value of the headers for the connection.
 	 *
-	 * @param  {Object} headers object representing the headers for the connection
+	 * @param  {object} headers object representing the headers for the connection
 	 * @return {Connect}        self
 	 */
 	headers(headers) {
@@ -206,7 +206,7 @@ class Connect {
 	 * Set the body of the connection object.
 	 *
 	 * @param  {*} body                    value for body
-	 * @param  {String} [contentType=null] string representing the content type of the body
+	 * @param  {string} [contentType=null] string representing the content type of the body
 	 * @return {Connect}                   self
 	 */
 	body(body, contentType = null) {
@@ -229,7 +229,7 @@ class Connect {
 	/**
 	 * Set the 'Referer' field in the headers.
 	 *
-	 * @param  {String} referer referer value
+	 * @param  {string} referer referer value
 	 * @return {Connect}
 	 */
 	referer(referer) {
@@ -240,7 +240,7 @@ class Connect {
 	/**
 	 * Set the 'User-Agent' field in the headers.
 	 *
-	 * @param  {String} userAgent name of the user-agent or its value
+	 * @param  {string} userAgent name of the user-agent or its value
 	 * @return {Connect}          self
 	 */
 	userAgent(userAgent) {
@@ -251,7 +251,7 @@ class Connect {
 	/**
 	 * Set the 'Content-Type' field in the headers.
 	 *
-	 * @param  {String} contentType value for content-type
+	 * @param  {string} contentType value for content-type
 	 * @return {Connect}
 	 */
 	contentType(contentType) {
@@ -262,7 +262,7 @@ class Connect {
 	/**
 	 * Returns whether the content-type is JSON or not
 	 *
-	 * @return {Boolean} true, if content-type is JSON; false, otherwise
+	 * @return {boolean} true, if content-type is JSON; false, otherwise
 	 */
 	isJSON() {
 		return this.options.headers['Content-Type'] === 'application/json';
@@ -275,9 +275,9 @@ class Connect {
 	 * Can also be used to set multiple cookies by passing in an object
 	 * representing the cookies and their values as key:value pairs.
 	 *
-	 * @param  {String|Boolean|Object} cookieName  represents the name of the
+	 * @param  {string|boolean|object} cookieName  represents the name of the
 	 * cookie to be set, or the cookies object
-	 * @param  {Object} cookieValue                cookie value to be set
+	 * @param  {object} cookieValue                cookie value to be set
 	 * @return {Connect}                           self
 	 */
 	cookie(cookieName, cookieValue) {
@@ -298,7 +298,7 @@ class Connect {
 	 * Sets multiple cookies.
 	 * Can be used to enable global cookies, if cookies is set to true.
 	 *
-	 * @param  {Object|Boolean} cookies object representing the cookies
+	 * @param  {object|boolean} cookies object representing the cookies
 	 * and their values as key:value pairs.
 	 * @return {Connect}                self
 	 */
@@ -316,7 +316,7 @@ class Connect {
 	/**
 	 * Enable global cookies.
 	 *
-	 * @param  {Boolean} [enableGlobalCookies=true] self-descriptive
+	 * @param  {boolean} [enableGlobalCookies=true] self-descriptive
 	 * @return {Connect}                            self
 	 */
 	globalCookies(enableGlobalCookies = true) {
@@ -327,7 +327,7 @@ class Connect {
 	/**
 	 * Set the value of cookie jar based on a file (cookie store).
 	 *
-	 * @param  {String} fileName name of (or path to) the file
+	 * @param  {string} fileName name of (or path to) the file
 	 * @return {Connect}         self
 	 */
 	cookieFile(fileName) {
@@ -350,7 +350,7 @@ class Connect {
 	/**
 	 * Set request timeout.
 	 *
-	 * @param  {Number} timeout timeout value in seconds
+	 * @param  {number} timeout timeout value in seconds
 	 * @return {Connect}        self
 	 */
 	timeout(timeout) {
@@ -361,7 +361,7 @@ class Connect {
 	/**
 	 * Set request timeout.
 	 *
-	 * @param  {Number} timeoutInMs timeout value in milliseconds
+	 * @param  {number} timeoutInMs timeout value in milliseconds
 	 * @return {Connect}            self
 	 */
 	timeoutMs(timeoutInMs) {
@@ -383,7 +383,7 @@ class Connect {
 	 * Can also be used to set multiple fields by passing in an object
 	 * representing the field-names and their values as key:value pairs.
 	 *
-	 * @param  {String|Object} fieldName name of the field to be set, or the fields object
+	 * @param  {string|object} fieldName name of the field to be set, or the fields object
 	 * @param  {*} fieldValue            value to be set
 	 * @return {Connect}                 self
 	 */
@@ -401,7 +401,7 @@ class Connect {
 	/**
 	 * Set multiple fields.
 	 *
-	 * @param  {Object} fields object representing the field-names and their
+	 * @param  {object} fields object representing the field-names and their
 	 * values as key:value pairs
 	 * @return {Connect}       self
 	 */
@@ -413,7 +413,7 @@ class Connect {
 	/**
 	 * Set the request method for the connection.
 	 *
-	 * @param  {String} method one of the HTTP request methods ('GET', 'PUT', 'POST', etc.)
+	 * @param  {string} method one of the HTTP request methods ('GET', 'PUT', 'POST', etc.)
 	 * @return {Connect}       self
 	 */
 	method(method) {
@@ -424,8 +424,8 @@ class Connect {
 	/**
 	 * Set username and password for authentication.
 	 *
-	 * @param  {String} username self-descriptive
-	 * @param  {String} password self-descriptive
+	 * @param  {string} username self-descriptive
+	 * @param  {string} password self-descriptive
 	 * @return {Connect}         self
 	 */
 	httpAuth(username, password) {
@@ -447,7 +447,7 @@ class Connect {
 	/**
 	 * Set proxy address (or options).
 	 *
-	 * @param  {String|Object} proxy proxy address, or object representing proxy options
+	 * @param  {string|object} proxy proxy address, or object representing proxy options
 	 * @return {Connect}             self
 	 */
 	proxy(proxy) {
@@ -471,8 +471,8 @@ class Connect {
 	/**
 	 * Set address and port for an http proxy.
 	 *
-	 * @param  {String} proxyAddress self-descriptive
-	 * @param  {Number} proxyPort    self-descriptive
+	 * @param  {string} proxyAddress self-descriptive
+	 * @param  {number} proxyPort    self-descriptive
 	 * @return {Connect}             self
 	 */
 	httpProxy(proxyAddress, proxyPort) {
@@ -488,8 +488,8 @@ class Connect {
 	/**
 	 * Set address and port for a socks proxy.
 	 *
-	 * @param  {String} proxyAddress self-descriptive
-	 * @param  {Number} proxyPort    self-descriptive
+	 * @param  {string} proxyAddress self-descriptive
+	 * @param  {number} proxyPort    self-descriptive
 	 * @return {Connect}             self
 	 */
 	socksProxy(proxyAddress, proxyPort) {
@@ -505,8 +505,8 @@ class Connect {
 	/**
 	 * Set username and password for proxy.
 	 *
-	 * @param  {String} username self-descriptive
-	 * @param  {String} password self-descriptive
+	 * @param  {string} username self-descriptive
+	 * @param  {string} password self-descriptive
 	 * @return {Connect}         self
 	 */
 	proxyAuth(username, password) {
@@ -558,7 +558,7 @@ class Connect {
 	/**
 	 * Set cache directory for the connection.
 	 *
-	 * @param  {String} dir name or path to the directory
+	 * @param  {string} dir name or path to the directory
 	 * @return {Connect}    self
 	 */
 	cacheDir(dir) {
@@ -569,7 +569,7 @@ class Connect {
 	/**
 	 * Set if the body is to be returned as a buffer
 	 *
-	 * @param  {Boolean} [returnAsBuffer=true] self-descriptive
+	 * @param  {boolean} [returnAsBuffer=true] self-descriptive
 	 * @return {Connect}                       self
 	 */
 	asBuffer(returnAsBuffer = true) {
@@ -580,7 +580,7 @@ class Connect {
 	/**
 	 * Set the path for file for saving the response.
 	 *
-	 * @param  {String} filePath self-descriptive
+	 * @param  {string} filePath self-descriptive
 	 * @return {Connect}         self
 	 */
 	save(filePath) {

--- a/docs/Crypt.html
+++ b/docs/Crypt.html
@@ -125,7 +125,7 @@
 
         
             
-<h4 class="name" id=".chars"><span class="type-signature">(static, constant) </span>chars<span class="type-signature"> :Object</span></h4>
+<h4 class="name" id=".chars"><span class="type-signature">(static, constant) </span>chars<span class="type-signature"> :object</span></h4>
 
 
 
@@ -185,7 +185,7 @@
     <ul>
         <li>
             
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
         </li>
@@ -1297,7 +1297,7 @@
 
     
 
-    <h4 class="name" id=".baseDecode"><span class="type-signature">(static) </span>baseDecode<span class="signature">(string, opts)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".baseDecode"><span class="type-signature">(static) </span>baseDecode<span class="signature">(string, opts)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -1393,7 +1393,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
 <span class="param-type">Buffer</span>
@@ -1422,7 +1422,7 @@
 <span class="param-type"><a href="global.html#encodingConversion">encodingConversion</a></span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1468,7 +1468,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -1578,7 +1578,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
 <span class="param-type">Buffer</span>
@@ -1604,7 +1604,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1663,7 +1663,7 @@
 
     
 
-    <h4 class="name" id=".baseEncode"><span class="type-signature">(static) </span>baseEncode<span class="signature">(string, opts)</span><span class="type-signature"> &rarr; {String|Buffer}</span></h4>
+    <h4 class="name" id=".baseEncode"><span class="type-signature">(static) </span>baseEncode<span class="signature">(string, opts)</span><span class="type-signature"> &rarr; {string|Buffer}</span></h4>
 
     
 
@@ -1759,7 +1759,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
 <span class="param-type">Buffer</span>
@@ -1788,7 +1788,7 @@
 <span class="param-type"><a href="global.html#encodingConversion">encodingConversion</a></span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1834,7 +1834,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
 <span class="param-type">Buffer</span>
@@ -1851,7 +1851,7 @@
 
     
 
-    <h4 class="name" id=".decrypt"><span class="type-signature">(static) </span>decrypt<span class="signature">(string, key, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".decrypt"><span class="type-signature">(static) </span>decrypt<span class="signature">(string, key, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -1951,7 +1951,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1986,7 +1986,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -2082,7 +2082,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -2096,7 +2096,7 @@
 
     
 
-    <h4 class="name" id=".decryptStatic"><span class="type-signature">(static) </span>decryptStatic<span class="signature">(string, key, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".decryptStatic"><span class="type-signature">(static) </span>decryptStatic<span class="signature">(string, key, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -2196,7 +2196,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -2231,7 +2231,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -2327,7 +2327,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -2341,7 +2341,7 @@
 
     
 
-    <h4 class="name" id=".encrypt"><span class="type-signature">(static) </span>encrypt<span class="signature">(string, key, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".encrypt"><span class="type-signature">(static) </span>encrypt<span class="signature">(string, key, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -2441,7 +2441,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -2476,7 +2476,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -2572,7 +2572,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -2586,7 +2586,7 @@
 
     
 
-    <h4 class="name" id=".encryptedTimestampedId"><span class="type-signature">(static) </span>encryptedTimestampedId<span class="signature">(options)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".encryptedTimestampedId"><span class="type-signature">(static) </span>encryptedTimestampedId<span class="signature">(options)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -2685,7 +2685,7 @@
 <span class="param-type">number</span>
 |
 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -2802,7 +2802,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -2816,7 +2816,7 @@
 
     
 
-    <h4 class="name" id=".encryptStatic"><span class="type-signature">(static) </span>encryptStatic<span class="signature">(string, key, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".encryptStatic"><span class="type-signature">(static) </span>encryptStatic<span class="signature">(string, key, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -2916,7 +2916,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -2951,7 +2951,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3047,7 +3047,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -3061,7 +3061,7 @@
 
     
 
-    <h4 class="name" id=".hash"><span class="type-signature">(static) </span>hash<span class="signature">(algo, string, opts<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".hash"><span class="type-signature">(static) </span>hash<span class="signature">(algo, string, opts<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -3161,7 +3161,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3196,7 +3196,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3292,7 +3292,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -3568,7 +3568,7 @@
 
     
 
-    <h4 class="name" id=".hmac"><span class="type-signature">(static) </span>hmac<span class="signature">(algo, string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".hmac"><span class="type-signature">(static) </span>hmac<span class="signature">(algo, string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -3668,7 +3668,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3703,7 +3703,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3799,7 +3799,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -3813,7 +3813,7 @@
 
     
 
-    <h4 class="name" id=".md5"><span class="type-signature">(static) </span>md5<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".md5"><span class="type-signature">(static) </span>md5<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -3913,7 +3913,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -4009,7 +4009,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -4023,7 +4023,7 @@
 
     
 
-    <h4 class="name" id=".nanoSecondsAlpha"><span class="type-signature">(static) </span>nanoSecondsAlpha<span class="signature">(base36)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".nanoSecondsAlpha"><span class="type-signature">(static) </span>nanoSecondsAlpha<span class="signature">(base36)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -4121,7 +4121,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -4172,7 +4172,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -4186,7 +4186,7 @@
 
     
 
-    <h4 class="name" id=".packNumbers"><span class="type-signature">(static) </span>packNumbers<span class="signature">(numbers)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".packNumbers"><span class="type-signature">(static) </span>packNumbers<span class="signature">(numbers)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -4327,7 +4327,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -4645,7 +4645,7 @@
 
     
 
-    <h4 class="name" id=".randomString"><span class="type-signature">(static) </span>randomString<span class="signature">(options)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".randomString"><span class="type-signature">(static) </span>randomString<span class="signature">(options)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -4790,7 +4790,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -5039,7 +5039,7 @@
 
     
 
-    <h4 class="name" id=".sequentialID"><span class="type-signature">(static) </span>sequentialID<span class="signature">(options)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".sequentialID"><span class="type-signature">(static) </span>sequentialID<span class="signature">(options)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -5139,7 +5139,7 @@
 <span class="param-type">number</span>
 |
 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -5184,7 +5184,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -5282,7 +5282,7 @@
 
     
 
-    <h4 class="name" id=".sha1"><span class="type-signature">(static) </span>sha1<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".sha1"><span class="type-signature">(static) </span>sha1<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -5382,7 +5382,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -5478,7 +5478,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -5492,7 +5492,7 @@
 
     
 
-    <h4 class="name" id=".sha1Hmac"><span class="type-signature">(static) </span>sha1Hmac<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".sha1Hmac"><span class="type-signature">(static) </span>sha1Hmac<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -5592,7 +5592,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -5688,7 +5688,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -5702,7 +5702,7 @@
 
     
 
-    <h4 class="name" id=".sha256"><span class="type-signature">(static) </span>sha256<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".sha256"><span class="type-signature">(static) </span>sha256<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -5802,7 +5802,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -5898,7 +5898,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -5912,7 +5912,7 @@
 
     
 
-    <h4 class="name" id=".sha256Hmac"><span class="type-signature">(static) </span>sha256Hmac<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".sha256Hmac"><span class="type-signature">(static) </span>sha256Hmac<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -6012,7 +6012,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -6108,7 +6108,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -6122,7 +6122,7 @@
 
     
 
-    <h4 class="name" id=".sha384"><span class="type-signature">(static) </span>sha384<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".sha384"><span class="type-signature">(static) </span>sha384<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -6222,7 +6222,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -6318,7 +6318,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -6332,7 +6332,7 @@
 
     
 
-    <h4 class="name" id=".sha512"><span class="type-signature">(static) </span>sha512<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".sha512"><span class="type-signature">(static) </span>sha512<span class="signature">(string, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -6432,7 +6432,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -6528,7 +6528,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -6542,7 +6542,7 @@
 
     
 
-    <h4 class="name" id=".shuffle"><span class="type-signature">(static) </span>shuffle<span class="signature">(itemToShuffle, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Array|String}</span></h4>
+    <h4 class="name" id=".shuffle"><span class="type-signature">(static) </span>shuffle<span class="signature">(itemToShuffle, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Array|string}</span></h4>
 
     
 
@@ -6645,7 +6645,7 @@
 <span class="param-type">Array</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -6680,7 +6680,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -6816,7 +6816,7 @@
 <span class="param-type">Array</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -6830,7 +6830,7 @@
 
     
 
-    <h4 class="name" id=".sign"><span class="type-signature">(static) </span>sign<span class="signature">(message, privateKey, opts)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".sign"><span class="type-signature">(static) </span>sign<span class="signature">(message, privateKey, opts)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -6929,7 +6929,7 @@ openssl ec -in private.pem -pubout -out public.pem</code></pre>
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -6952,10 +6952,10 @@ openssl ec -in private.pem -pubout -out public.pem</code></pre>
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -7024,7 +7024,7 @@ openssl ec -in private.pem -pubout -out public.pem</code></pre>
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -7334,7 +7334,7 @@ openssl ec -in private.pem -pubout -out public.pem</code></pre>
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -7393,7 +7393,7 @@ openssl ec -in private.pem -pubout -out public.pem</code></pre>
 
     
 
-    <h4 class="name" id=".verify"><span class="type-signature">(static) </span>verify<span class="signature">(message, signature, publicKey, opts<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Boolean}</span></h4>
+    <h4 class="name" id=".verify"><span class="type-signature">(static) </span>verify<span class="signature">(message, signature, publicKey, opts<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {boolean}</span></h4>
 
     
 
@@ -7496,7 +7496,7 @@ openssl ec -in private.pem -pubout -out public.pem</code></pre>
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -7531,7 +7531,7 @@ openssl ec -in private.pem -pubout -out public.pem</code></pre>
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -7566,10 +7566,10 @@ openssl ec -in private.pem -pubout -out public.pem</code></pre>
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -7665,7 +7665,7 @@ openssl ec -in private.pem -pubout -out public.pem</code></pre>
     </dt>
     <dd>
         
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
     </dd>

--- a/docs/Crypt_Crypt.js.html
+++ b/docs/Crypt_Crypt.js.html
@@ -62,7 +62,7 @@ const gzdeflate = promisify(zlib.deflateRaw);
 /**
  * different charsets available
  * @memberof Crypt
- * @type {Object}
+ * @type {object}
  */
 const chars = {};
 
@@ -128,7 +128,7 @@ function countBits(number) {
 /**
  * @typedef {object} randomOpts
  * @property {number} length integer
- * @property {Boolean} base36 if true will use BASE_36 charset
+ * @property {boolean} base36 if true will use BASE_36 charset
  * @property {string} charset provide a charset string
  */
 
@@ -142,7 +142,7 @@ function countBits(number) {
  *
  * @memberof Crypt
  * @param  {number|randomOpts} options length of the id or options object
- * @return {String} id
+ * @return {string} id
  */
 function randomString(options = {}) {
 	let length;
@@ -208,11 +208,11 @@ function randomString(options = {}) {
  * Shuffle an array or a string.
  *
  * @memberof Crypt
- * @param {Array|String} itemToShuffle item which you want to shuffle
- * @param {Object} [options = {}] object of {seed: number}
+ * @param {Array|string} itemToShuffle item which you want to shuffle
+ * @param {object} [options = {}] object of {seed: number}
  * @param {function} options.randomFunc Use this random function instead of default
  * @param {number} options.seed optionally give a seed to do a constant shuffle
- * @return {Array|String} shuffled item
+ * @return {Array|string} shuffled item
  */
 function shuffle(itemToShuffle, options = {}) {
 	let array;
@@ -315,8 +315,8 @@ function seededRandom(seed) {
  * Get nanoseconds in base62 or base36 format.
  *
  * @memberof Crypt
- * @param {Boolean} base36 use base36 format or not
- * @return {String} nanoseconds
+ * @param {boolean} base36 use base36 format or not
+ * @return {string} nanoseconds
  */
 function nanoSecondsAlpha(base36 = false) {
 	const hrtime = process.hrtime();
@@ -340,8 +340,8 @@ function nanoSecondsAlpha(base36 = false) {
  * NOTE: Multiple call within the same millisecond will return 1, 2, 3 so on..
  * The counter will reset on next millisecond
  *
- * @param  {Number} currentTime self-descriptive
- * @return {Number} sequential number
+ * @param  {number} currentTime self-descriptive
+ * @return {number} sequential number
  * @ignore
  */
 function msCounter(currentTime) {
@@ -362,8 +362,8 @@ function msCounter(currentTime) {
  * NOTE: For best results use atleast 15 characters in base62 and 18 characters in base36 encoding
  *
  * @memberof Crypt
- * @param {number|Object} options length of the id or object of {length: int, base36: bool}
- * @return {String} id
+ * @param {number|object} options length of the id or object of {length: int, base36: bool}
+ * @return {string} id
  */
 function sequentialID(options) {
 	let length = 20;
@@ -419,8 +419,8 @@ function sequentialID(options) {
  * where x is any hexadecimal digit and y is one of 8, 9, a, or b
  * eg. f47ac10b-58cc-4372-a567-0e02b2c3d479
  *
- * @param  {String} str the hex string
- * @return {String} the modified string
+ * @param  {string} str the hex string
+ * @return {string} the modified string
  * @private
  */
 function addDashesForUUID(str) {
@@ -465,9 +465,9 @@ function randomUUID() {
  *   'utf8', 'buffer', 'utf16le' ('ucs2')
  *
  * @memberof Crypt
- * @param  {String|Buffer} string item to be encoded
- * @param  {encodingConversion|String} opts   object or string specifying the encoding(s)
- * @return {String|Buffer}        encoded item
+ * @param  {string|Buffer} string item to be encoded
+ * @param  {encodingConversion|string} opts   object or string specifying the encoding(s)
+ * @return {string|Buffer}        encoded item
  *
  * NOTE: If opts is a string, it is considered as the toEncoding.
  * The fromEncoding defaults to binary, while the toEncoding defaults to base64url.
@@ -512,9 +512,9 @@ function baseEncode(string, opts) {
  * Decode a string encoded using a given encoding.
  *
  * @memberof Crypt
- * @param  {String|Buffer} string item to be decoded
- * @param  {encodingConversion|String} opts   object or string specifying the encoding(s)
- * @return {String}        decoded item
+ * @param  {string|Buffer} string item to be decoded
+ * @param  {encodingConversion|string} opts   object or string specifying the encoding(s)
+ * @return {string}        decoded item
  *
  * NOTE: If opts is a string, it is considered as the fromEncoding
  * (i.e that was used to encode the string).
@@ -534,8 +534,8 @@ function baseDecode(string, opts) {
  * Decode a string encoded using a given encoding to a buffer.
  *
  * @memberof Crypt
- * @param  {String|Buffer} string item to be decoded
- * @param  {String} fromEncoding  encoding used to encode the string
+ * @param  {string|Buffer} string item to be decoded
+ * @param  {string} fromEncoding  encoding used to encode the string
  * @return {Buffer}        decoded item
  */
 function baseDecodeToBuffer(string, fromEncoding) {
@@ -559,10 +559,10 @@ function baseDecodeToBuffer(string, fromEncoding) {
  * encoding can be 'hex', 'binary' ('latin1'), 'ascii', 'base64', 'base64url', 'utf8', 'buffer'
  *
  * @memberof Crypt
- * @param {String} algo                      algo to be used for hashing
- * @param {String} string                    string to be hashed
+ * @param {string} algo                      algo to be used for hashing
+ * @param {string} string                    string to be hashed
  * @param {encodingOpts} [opts={}]
- * @return {String}                           encoded hash value
+ * @return {string}                           encoded hash value
  */
 function hash(algo, string, {encoding = 'hex'} = {}) {
 	const hashed = crypto.createHash(algo).update(string);
@@ -579,9 +579,9 @@ function hash(algo, string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using md5
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function md5(string, {encoding = 'hex'} = {}) {
 	return hash('md5', string, {encoding});
@@ -591,9 +591,9 @@ function md5(string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using sha1
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function sha1(string, {encoding = 'hex'} = {}) {
 	return hash('sha1', string, {encoding});
@@ -603,9 +603,9 @@ function sha1(string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using sha256
  *
  * @memberof Crypt
- * @param  {String} string string to be hashed
+ * @param  {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function sha256(string, {encoding = 'hex'} = {}) {
 	return hash('sha256', string, {encoding});
@@ -615,9 +615,9 @@ function sha256(string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using sha384
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function sha384(string, {encoding = 'hex'} = {}) {
 	return hash('sha384', string, {encoding});
@@ -627,9 +627,9 @@ function sha384(string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using sha512
  *
  * @memberof Crypt
- * @param  {String} string string to be hashed
+ * @param  {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function sha512(string, {encoding = 'hex'} = {}) {
 	return hash('sha512', string, {encoding});
@@ -639,10 +639,10 @@ function sha512(string, {encoding = 'hex'} = {}) {
  * Create cryptographic HMAC digests using given algo
  *
  * @memberof Crypt
- * @param {String} algo algo to be used for hashing
- * @param {String} string string to be hashed
+ * @param {string} algo algo to be used for hashing
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded HMAC digest
+ * @return {string} encoded HMAC digest
  */
 function hmac(algo, string, key, {encoding = 'hex'} = {}) {
 	if (typeof key === 'string') key = Buffer.from(key, 'binary');
@@ -660,9 +660,9 @@ function hmac(algo, string, key, {encoding = 'hex'} = {}) {
  * Create cryptographic HMAC digests using sha1
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded HMAC digest
+ * @return {string} encoded HMAC digest
  */
 function sha1Hmac(string, key, {encoding = 'hex'} = {}) {
 	return hmac('sha1', string, key, {encoding});
@@ -672,9 +672,9 @@ function sha1Hmac(string, key, {encoding = 'hex'} = {}) {
  * Create cryptographic HMAC digests using sha256
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded HMAC digest
+ * @return {string} encoded HMAC digest
  */
 function sha256Hmac(string, key, {encoding = 'hex'} = {}) {
 	return hmac('sha256', string, key, {encoding});
@@ -690,10 +690,10 @@ function sha256Hmac(string, key, {encoding = 'hex'} = {}) {
  * ```
  *
  * @memberof Crypt
- * @param  {String} message           the message to be signed
- * @param  {String|Object} privateKey self-descriptive
+ * @param  {string} message           the message to be signed
+ * @param  {string|object} privateKey self-descriptive
  * @param  {encodingOpts} opts        opts can have {encoding (default 'hex')
- * @return {String}                   signature
+ * @return {string}                   signature
  *
  * NOTE: If privateKey is a string, it is treated as a raw key with no passphrase.
  * If privateKey is an object, it must contain the following property:
@@ -722,11 +722,11 @@ function sign(message, privateKey, opts = {}) {
  * ```
  *
  * @memberof Crypt
- * @param  {String} message          message to be verified
- * @param  {String} signature        self-descriptive
- * @param  {String|Object} publicKey self-descriptive
+ * @param  {string} message          message to be verified
+ * @param  {string} signature        self-descriptive
+ * @param  {string|object} publicKey self-descriptive
  * @param  {encodingOpts} [opts={}]  opts can have {encoding (default 'hex')}
- * @return {Boolean}                 true or false, depending on the validity of
+ * @return {boolean}                 true or false, depending on the validity of
  * the signature for the data and public key
  */
 function verify(message, signature, publicKey, opts = {}) {
@@ -752,10 +752,10 @@ function verify(message, signature, publicKey, opts = {}) {
  * Optionally specify encoding in which you want to get the output
  *
  * @memberof Crypt
- * @param  {String} string                          string to be encrypted
- * @param  {String} key                             key to be used
+ * @param  {string} string                          string to be encrypted
+ * @param  {string} key                             key to be used
  * @param {encodingOpts} [options={}] object of {encoding} (default: 'base64url')
- * @return {String}                                 encrypted string
+ * @return {string}                                 encrypted string
  */
 function encrypt(string, key, {encoding = 'base64url'} = {}) {
 	if (string.length &lt; 6) {
@@ -778,10 +778,10 @@ function encrypt(string, key, {encoding = 'base64url'} = {}) {
  * Decrypt the given string with the given key encrypted using encrypt
  *
  * @memberof Crypt
- * @param  {String} string                          string to be decrypted
- * @param  {String} key                             key to be used
+ * @param  {string} string                          string to be decrypted
+ * @param  {string} key                             key to be used
  * @param {encodingOpts} [options={}] object of {encoding} (default: 'base64url')
- * @return {String}                                 decrypted string
+ * @return {string}                                 decrypted string
  */
 function decrypt(string, key, {encoding = 'base64url'} = {}) {
 	if (key.length !== 32) {
@@ -804,10 +804,10 @@ function decrypt(string, key, {encoding = 'base64url'} = {}) {
  * for same string and key.
  *
  * @memberof Crypt
- * @param  {String} string                          string to be encrypted
- * @param  {String} key                             key to be used
+ * @param  {string} string                          string to be encrypted
+ * @param  {string} key                             key to be used
  * @param {encodingOpts} [options={}] object of {encoding} (default: 'base64url')
- * @return {String}                                 encrypted string
+ * @return {string}                                 encrypted string
  */
 function encryptStatic(string, key, {encoding = 'base64url'} = {}) {
 	if (string.length &lt; 6) {
@@ -823,10 +823,10 @@ function encryptStatic(string, key, {encoding = 'base64url'} = {}) {
  * Decrypt the given string with the given key encrypted using encryptStatic
  *
  * @memberof Crypt
- * @param  {String} string                          string to be decrypted
- * @param  {String} key                             key to be used
+ * @param  {string} string                          string to be decrypted
+ * @param  {string} key                             key to be used
  * @param {encodingOpts} [options={}] object of {encoding} (default: 'base64url')
- * @return {String}                                 decrypted string
+ * @return {string}                                 decrypted string
  */
 function decryptStatic(string, key, {encoding = 'base64url'} = {}) {
 	const version = string.substring(0, 1);  // eslint-disable-line
@@ -972,7 +972,7 @@ function base64UrlDecode(string, toEncoding = 'binary') {
  *
  * @memberof Crypt
  * @param  {Array} numbers array of numbers to be packed
- * @return {String}        packed string
+ * @return {string}        packed string
  */
 function packNumbers(numbers) {
 	return baseConvert(
@@ -985,7 +985,7 @@ function packNumbers(numbers) {
  * Unpack a string packed with packNumbers
  *
  * @memberof Crypt
- * @param  {String} str string to be unpacked
+ * @param  {string} str string to be unpacked
  * @return {Array}      array of unpacked numbers
  */
 function unpackNumbers(str) {
@@ -1000,10 +1000,10 @@ function unpackNumbers(str) {
  * Generate a random encrypted string that contains a timestamp.
  *
  * @memberof Crypt
- * @param {number|Object} options length of the id or object of {length: int}
+ * @param {number|object} options length of the id or object of {length: int}
  * @param {number} options.length
  * @param {number} options.time epoch time / 1000
- * @return {String} id
+ * @return {string} id
  */
 function encryptedTimestampedId(options, key) {
 	const length = options.length || options;
@@ -1029,8 +1029,8 @@ function encryptedTimestampedId(options, key) {
  * Legacy obfuscation method
  *
  * @memberof Crypt
- * @param  {String} str the string to be obfuscted
- * @return {String} obfuscated string
+ * @param  {string} str the string to be obfuscted
+ * @return {string} obfuscated string
  * @ignore
  */
 async function javaObfuscate(str) {
@@ -1047,8 +1047,8 @@ async function javaObfuscate(str) {
  * Legacy unobfuscation method (obfuscated by javaObfuscate)
  *
  * @memberof Crypt
- * @param  {String} str the obfuscted string
- * @return {String} unobfuscated string
+ * @param  {string} str the obfuscted string
+ * @return {string} unobfuscated string
  * @ignore
  */
 async function javaUnobfuscate(str) {

--- a/docs/File.html
+++ b/docs/File.html
@@ -76,7 +76,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line18">line 18</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line42">line 42</a>
     </li></ul></dd>
     
 
@@ -160,7 +160,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -228,7 +228,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line380">line 380</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line404">line 404</a>
     </li></ul></dd>
     
 
@@ -316,7 +316,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
 <span class="param-type">Buffer</span>
@@ -354,7 +354,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -420,7 +420,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line119">line 119</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line143">line 143</a>
     </li></ul></dd>
     
 
@@ -514,7 +514,7 @@
 
     
 
-    <h4 class="name" id="chmod"><span class="type-signature">(async) </span>chmod<span class="signature">(mode)</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="chmod"><span class="type-signature">(async) </span>chmod<span class="signature">(mode)</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -526,7 +526,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line184">line 184</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line208">line 208</a>
     </li></ul></dd>
     
 
@@ -610,10 +610,10 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -658,7 +658,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -672,7 +672,7 @@
 
     
 
-    <h4 class="name" id="chmodr"><span class="type-signature">(async) </span>chmodr<span class="signature">(mode)</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="chmodr"><span class="type-signature">(async) </span>chmodr<span class="signature">(mode)</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -684,7 +684,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line194">line 194</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line218">line 218</a>
     </li></ul></dd>
     
 
@@ -768,10 +768,10 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -816,7 +816,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -830,7 +830,7 @@
 
     
 
-    <h4 class="name" id="chown"><span class="type-signature">(async) </span>chown<span class="signature">(user, group)</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="chown"><span class="type-signature">(async) </span>chown<span class="signature">(user, group)</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -842,7 +842,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line207">line 207</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line231">line 231</a>
     </li></ul></dd>
     
 
@@ -926,10 +926,10 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -952,10 +952,10 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1001,7 +1001,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -1015,7 +1015,7 @@
 
     
 
-    <h4 class="name" id="chownr"><span class="type-signature">(async) </span>chownr<span class="signature">(user, group)</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="chownr"><span class="type-signature">(async) </span>chownr<span class="signature">(user, group)</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -1027,7 +1027,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line224">line 224</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line248">line 248</a>
     </li></ul></dd>
     
 
@@ -1111,10 +1111,10 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1137,10 +1137,10 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1186,7 +1186,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -1212,7 +1212,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line411">line 411</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line435">line 435</a>
     </li></ul></dd>
     
 
@@ -1300,7 +1300,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1335,7 +1335,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -1401,7 +1401,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line133">line 133</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line157">line 157</a>
     </li></ul></dd>
     
 
@@ -1507,7 +1507,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line105">line 105</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line129">line 129</a>
     </li></ul></dd>
     
 
@@ -1601,7 +1601,7 @@
 
     
 
-    <h4 class="name" id="exists"><span class="type-signature">(async) </span>exists<span class="signature">()</span><span class="type-signature"> &rarr; {Boolean}</span></h4>
+    <h4 class="name" id="exists"><span class="type-signature">(async) </span>exists<span class="signature">()</span><span class="type-signature"> &rarr; {boolean}</span></h4>
 
     
 
@@ -1613,7 +1613,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line33">line 33</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line57">line 57</a>
     </li></ul></dd>
     
 
@@ -1693,7 +1693,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
     </dd>
@@ -1707,7 +1707,7 @@
 
     
 
-    <h4 class="name" id="existsSync"><span class="type-signature"></span>existsSync<span class="signature">()</span><span class="type-signature"> &rarr; {Boolean}</span></h4>
+    <h4 class="name" id="existsSync"><span class="type-signature"></span>existsSync<span class="signature">()</span><span class="type-signature"> &rarr; {boolean}</span></h4>
 
     
 
@@ -1719,7 +1719,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line48">line 48</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line72">line 72</a>
     </li></ul></dd>
     
 
@@ -1799,7 +1799,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
     </dd>
@@ -1825,7 +1825,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line321">line 321</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line345">line 345</a>
     </li></ul></dd>
     
 
@@ -1919,7 +1919,7 @@
 
     
 
-    <h4 class="name" id="isDir"><span class="type-signature">(async) </span>isDir<span class="signature">()</span><span class="type-signature"> &rarr; {Boolean}</span></h4>
+    <h4 class="name" id="isDir"><span class="type-signature">(async) </span>isDir<span class="signature">()</span><span class="type-signature"> &rarr; {boolean}</span></h4>
 
     
 
@@ -1931,7 +1931,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line77">line 77</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line101">line 101</a>
     </li></ul></dd>
     
 
@@ -2011,7 +2011,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
     </dd>
@@ -2025,7 +2025,7 @@
 
     
 
-    <h4 class="name" id="isFile"><span class="type-signature">(async) </span>isFile<span class="signature">()</span><span class="type-signature"> &rarr; {Boolean}</span></h4>
+    <h4 class="name" id="isFile"><span class="type-signature">(async) </span>isFile<span class="signature">()</span><span class="type-signature"> &rarr; {boolean}</span></h4>
 
     
 
@@ -2037,7 +2037,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line63">line 63</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line87">line 87</a>
     </li></ul></dd>
     
 
@@ -2117,7 +2117,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
     </dd>
@@ -2131,7 +2131,7 @@
 
     
 
-    <h4 class="name" id="lstat"><span class="type-signature">(async) </span>lstat<span class="signature">()</span><span class="type-signature"> &rarr; {Object}</span></h4>
+    <h4 class="name" id="lstat"><span class="type-signature">(async) </span>lstat<span class="signature">()</span><span class="type-signature"> &rarr; {object}</span></h4>
 
     
 
@@ -2143,7 +2143,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line148">line 148</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line172">line 172</a>
     </li></ul></dd>
     
 
@@ -2223,7 +2223,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
     </dd>
@@ -2249,7 +2249,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line303">line 303</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line327">line 327</a>
     </li></ul></dd>
     
 
@@ -2337,7 +2337,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -2402,7 +2402,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line312">line 312</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line336">line 336</a>
     </li></ul></dd>
     
 
@@ -2490,7 +2490,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -2555,7 +2555,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line339">line 339</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line363">line 363</a>
     </li></ul></dd>
     
 
@@ -2643,7 +2643,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -2708,7 +2708,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line91">line 91</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line115">line 115</a>
     </li></ul></dd>
     
 
@@ -2802,7 +2802,7 @@
 
     
 
-    <h4 class="name" id="mv"><span class="type-signature">(async) </span>mv<span class="signature">(newName)</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="mv"><span class="type-signature">(async) </span>mv<span class="signature">(newName)</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -2814,7 +2814,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line256">line 256</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line280">line 280</a>
     </li></ul></dd>
     
 
@@ -2898,7 +2898,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -2943,7 +2943,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -2957,7 +2957,7 @@
 
     
 
-    <h4 class="name" id="read"><span class="type-signature">(async) </span>read<span class="signature">()</span><span class="type-signature"> &rarr; {String|Buffer}</span></h4>
+    <h4 class="name" id="read"><span class="type-signature">(async) </span>read<span class="signature">()</span><span class="type-signature"> &rarr; {string|Buffer}</span></h4>
 
     
 
@@ -2969,7 +2969,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line330">line 330</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line354">line 354</a>
     </li></ul></dd>
     
 
@@ -3049,7 +3049,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
 <span class="param-type">Buffer</span>
@@ -3066,7 +3066,7 @@
 
     
 
-    <h4 class="name" id="realpath"><span class="type-signature">(async) </span>realpath<span class="signature">()</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id="realpath"><span class="type-signature">(async) </span>realpath<span class="signature">()</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -3078,7 +3078,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line428">line 428</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line452">line 452</a>
     </li></ul></dd>
     
 
@@ -3158,7 +3158,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -3172,7 +3172,7 @@
 
     
 
-    <h4 class="name" id="realpathSync"><span class="type-signature"></span>realpathSync<span class="signature">()</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id="realpathSync"><span class="type-signature"></span>realpathSync<span class="signature">()</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -3184,7 +3184,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line437">line 437</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line461">line 461</a>
     </li></ul></dd>
     
 
@@ -3264,7 +3264,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -3278,7 +3278,7 @@
 
     
 
-    <h4 class="name" id="rename"><span class="type-signature">(async) </span>rename<span class="signature">(newName)</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="rename"><span class="type-signature">(async) </span>rename<span class="signature">(newName)</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -3290,7 +3290,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line238">line 238</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line262">line 262</a>
     </li></ul></dd>
     
 
@@ -3374,7 +3374,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3419,7 +3419,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -3445,7 +3445,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line278">line 278</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line302">line 302</a>
     </li></ul></dd>
     
 
@@ -3530,7 +3530,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line287">line 287</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line311">line 311</a>
     </li></ul></dd>
     
 
@@ -3615,7 +3615,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line294">line 294</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line318">line 318</a>
     </li></ul></dd>
     
 
@@ -3687,7 +3687,7 @@
 
     
 
-    <h4 class="name" id="size"><span class="type-signature">(async) </span>size<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="size"><span class="type-signature">(async) </span>size<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -3699,7 +3699,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line169">line 169</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line193">line 193</a>
     </li></ul></dd>
     
 
@@ -3779,7 +3779,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -3793,7 +3793,7 @@
 
     
 
-    <h4 class="name" id="stat"><span class="type-signature">(async) </span>stat<span class="signature">()</span><span class="type-signature"> &rarr; {Object}</span></h4>
+    <h4 class="name" id="stat"><span class="type-signature">(async) </span>stat<span class="signature">()</span><span class="type-signature"> &rarr; {object}</span></h4>
 
     
 
@@ -3805,7 +3805,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line158">line 158</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line182">line 182</a>
     </li></ul></dd>
     
 
@@ -3885,7 +3885,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
     </dd>
@@ -3911,7 +3911,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line267">line 267</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line291">line 291</a>
     </li></ul></dd>
     
 
@@ -3996,7 +3996,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line351">line 351</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line375">line 375</a>
     </li></ul></dd>
     
 
@@ -4084,7 +4084,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
 <span class="param-type">Buffer</span>
@@ -4122,7 +4122,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             

--- a/docs/File.js.html
+++ b/docs/File.js.html
@@ -44,17 +44,41 @@
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>const _ = require('lodash');
-const promisify = require('thenify-all');
+const {promisify} = require('util');
 const _path = require('path');
-const _rimraf = promisify(require('rimraf'));
-const _mkdirp = promisify(require('mkdirp'));
-const _glob = promisify(require('glob'));
-const _chmodr = promisify(require('chmodr'));
-const _chownr = promisify(require('chownr'));
 const System = require('./System');
 const _fs = require('fs');
 
-const fs = promisify(_fs);
+// TODO: replace this with fs.promises when it becomes stable
+const fs = {};
+const methods = [
+	'lstat',
+	'stat',
+	'chmod',
+	'realpath',
+	'copyFile',
+	'appendFile',
+	'writeFile',
+	'readFile',
+	'mkdir',
+	'chown',
+	'rename',
+	'unlink',
+	'rmdir',
+];
+methods.forEach((method) => {
+	fs[method] = promisify(_fs[method]);
+});
+
+const moduleCache = {};
+function getModule(name) {
+	if (!moduleCache[name]) {
+		// eslint-disable-next-line  global-require, import/no-dynamic-require
+		moduleCache[name] = promisify(require(name));
+	}
+
+	return moduleCache[name];
+}
 
 /**
  * File System utilities wrapped in a class
@@ -64,7 +88,7 @@ class File {
 	/**
 	 * Creates a new File object.
 	 *
-	 * @param  {String} path path to the file
+	 * @param  {string} path path to the file
 	 */
 	constructor(path) {
 		this.path = path;
@@ -73,7 +97,7 @@ class File {
 	/**
 	 * Checks whether a file exists already.
 	 *
-	 * @return {Boolean} true, if the file exists; false, otherwise
+	 * @return {boolean} true, if the file exists; false, otherwise
 	 */
 	async exists() {
 		try {
@@ -88,7 +112,7 @@ class File {
 	/**
 	* Checks whether a file exists already.
 	*
-	* @return {Boolean} true, if the file exists; false, otherwise
+	* @return {boolean} true, if the file exists; false, otherwise
 	 */
 	existsSync() {
 		try {
@@ -103,7 +127,7 @@ class File {
 	/**
 	 * Returns whether this File object represents a file.
 	 *
-	 * @return {Boolean} true, if this object represents a file; false, otherwise
+	 * @return {boolean} true, if this object represents a file; false, otherwise
 	 */
 	async isFile() {
 		try {
@@ -117,7 +141,7 @@ class File {
 	/**
 	 * Returns whether this File object represents a directory.
 	 *
-	 * @return {Boolean} true, if this object represents a directory; false, otherwise
+	 * @return {boolean} true, if this object represents a directory; false, otherwise
 	 */
 	async isDir() {
 		try {
@@ -188,7 +212,7 @@ class File {
 	 * Returns an object with the stats of the file. If the path for the file
 	 * is a symlink, then stats of the symlink are returned.
 	 *
-	 * @return {Object} Stats object
+	 * @return {object} Stats object
 	 */
 	async lstat() {
 		return fs.lstat(this.path);
@@ -198,7 +222,7 @@ class File {
 	 * Returns an object with the stats of the file. If the path for the file
 	 * is a symlink, then stats of the target of the symlink are returned.
 	 *
-	 * @return {Object} Stats object
+	 * @return {object} Stats object
 	 */
 	async stat() {
 		return fs.stat(this.path);
@@ -209,7 +233,7 @@ class File {
 	 * Returns the size of the file in bytes. If the file is not found
 	 * or can't be read successfully, 0 is returned.
 	 *
-	 * @return {Number} Size of file (in bytes)
+	 * @return {number} Size of file (in bytes)
 	 */
 	async size() {
 		try {
@@ -223,8 +247,8 @@ class File {
 	/**
 	 * Change the mode of the file.
 	 *
-	 * @param  {Number|String}  mode An octal number or a string representing the file mode
-	 * @return {Number}              0, on success; -1, if some error occurred
+	 * @param  {number|string}  mode An octal number or a string representing the file mode
+	 * @return {number}              0, on success; -1, if some error occurred
 	 */
 	async chmod(mode) {
 		return fs.chmod(this.path, mode);
@@ -233,19 +257,19 @@ class File {
 	/**
 	 * Change the mode of the file or directory recursively.
 	 *
-	 * @param  {Number|String}  mode An octal number or a string representing the file mode
-	 * @return {Number}              0, on success; -1, if some error occurred
+	 * @param  {number|string}  mode An octal number or a string representing the file mode
+	 * @return {number}              0, on success; -1, if some error occurred
 	 */
 	async chmodr(mode) {
-		return _chmodr(this.path, mode);
+		return getModule('chmodr')(this.path, mode);
 	}
 
 	/**
 	 * Change the owner and group of the file.
 	 *
-	 * @param  {Number|String} user  user id, or user name
-	 * @param  {Number|String} group group id, or group name
-	 * @return {Number}              0, on success; any other number, if some error occurred
+	 * @param  {number|string} user  user id, or user name
+	 * @param  {number|string} group group id, or group name
+	 * @return {number}              0, on success; any other number, if some error occurred
 	 *
 	 * NOTE: If the owner or group is specified as -1, then that ID is not changed
 	 */
@@ -260,15 +284,15 @@ class File {
 	/**
 	 * Change the owner and group of the file recursively.
 	 *
-	 * @param  {Number|String} user  user id, or user name
-	 * @param  {Number|String} group group id, or group name
-	 * @return {Number}              0, on success; any other number, if some error occurred
+	 * @param  {number|string} user  user id, or user name
+	 * @param  {number|string} group group id, or group name
+	 * @return {number}              0, on success; any other number, if some error occurred
 	 *
 	 * NOTE: If the owner or group is specified as -1, then that ID is not changed
 	 */
 	async chownr(user, group) {
 		if (Number.isInteger(user) &amp;&amp; Number.isInteger(group)) {
-			return _chownr(this.path, user, group);
+			return getModule('chownr')(this.path, user, group);
 		}
 
 		return System.execOut(`chown -R ${user}:${group} ${this.path}`);
@@ -277,8 +301,8 @@ class File {
 	/**
 	 * Change the name or location of the file.
 	 *
-	 * @param  {String} newName new path/location (not just name) for the file
-	 * @return {Number}         0, on success; -1, if some error occurred
+	 * @param  {string} newName new path/location (not just name) for the file
+	 * @return {number}         0, on success; -1, if some error occurred
 	 */
 	async rename(newName) {
 		try {
@@ -295,8 +319,8 @@ class File {
 	/**
 	 * Move file to a new location
 	 *
-	 * @param  {String} newName new location (or path) for the file
-	 * @return {Number}         0, on success; -1, if some error occurred
+	 * @param  {string} newName new location (or path) for the file
+	 * @return {number}         0, on success; -1, if some error occurred
 	 */
 	async mv(newName) {
 		return this.rename(newName);
@@ -337,13 +361,13 @@ class File {
 	 * Recursively delete the directory and all its contents.
 	 */
 	async rmrf() {
-		return _rimraf(this.path);
+		return getModule('rimraf')(this.path);
 	}
 
 	/**
 	 * Create a directory.
 	 *
-	 * @param  {Number} [mode = 0o755] file mode for the directory
+	 * @param  {number} [mode = 0o755] file mode for the directory
 	 */
 	async mkdir(mode = 0o755) {
 		return fs.mkdir(this.path, mode);
@@ -352,10 +376,10 @@ class File {
 	/**
 	 * Create a new directory and any necessary subdirectories.
 	 *
-	 * @param  {Number} [mode = 0o755] file mode for the directory
+	 * @param  {number} [mode = 0o755] file mode for the directory
 	 */
 	async mkdirp(mode = 0o755) {
-		return _mkdirp(this.path, mode);
+		return getModule('mkdirp')(this.path, mode);
 	}
 
 	/**
@@ -364,13 +388,13 @@ class File {
 	 * @return {Array} Array containing the matches
 	 */
 	async glob() {
-		return _glob(this.path);
+		return getModule('glob')(this.path);
 	}
 
 	/**
 	 * Read contents of the file.
 	 *
-	 * @return {String|Buffer} contents of the file
+	 * @return {string|Buffer} contents of the file
 	 */
 	async read() {
 		return fs.readFile(this.path, 'utf8');
@@ -379,17 +403,17 @@ class File {
 	/**
 	 * Create (all necessary directories for) the path of the file/directory.
 	 *
-	 * @param  {Number} [mode = 0o755] file mode for the directory
+	 * @param  {number} [mode = 0o755] file mode for the directory
 	 */
 	async mkdirpPath(mode = 0o755) {
-		return _mkdirp(_path.dirname(this.path), mode);
+		return getModule('mkdirp')(_path.dirname(this.path), mode);
 	}
 
 	/**
 	 * Write contents to the file.
 	 *
-	 * @param  {String|Buffer} contents contents to be written to the file
-	 * @param  {Object} [options = {}]  contains options for writing to the file
+	 * @param  {string|Buffer} contents contents to be written to the file
+	 * @param  {object} [options = {}]  contains options for writing to the file
 	 *
 	 * The options can include parameters such as fileMode, dirMode, retries and encoding.
 	 */
@@ -417,8 +441,8 @@ class File {
 	/**
 	 * Append contents to the file.
 	 *
-	 * @param  {String|Buffer} contents contents to be written to the file
-	 * @param  {Object} [options = {}]  contains options for appending to the file
+	 * @param  {string|Buffer} contents contents to be written to the file
+	 * @param  {object} [options = {}]  contains options for appending to the file
 	 *
 	 * The options can include parameters such as fileMode, dirMode, retries and encoding.
 	 */
@@ -446,8 +470,8 @@ class File {
 	/**
 	 * Copy the file to some destination.
 	 *
-	 * @param  {String} destination    path of the destination
-	 * @param  {Object} [options = {}] options for copying the file
+	 * @param  {string} destination    path of the destination
+	 * @param  {object} [options = {}] options for copying the file
 	 *
 	 * If the overwrite option is explicitly set to false, only then
 	 * will the function not attempt to overwrite the file if it (already)
@@ -468,7 +492,7 @@ class File {
 	/**
 	 * Return the canonicalized absolute pathname
 	 *
-	 * @return {String} the resolved path
+	 * @return {string} the resolved path
 	 */
 	async realpath() {
 		return fs.realpath(this.path);
@@ -477,7 +501,7 @@ class File {
 	/**
 	 * Return the canonicalized absolute pathname
 	 *
-	 * @return {String} the resolved path
+	 * @return {string} the resolved path
 	 */
 	realpathSync() {
 		return _fs.realpathSync(this.path);
@@ -487,7 +511,7 @@ class File {
 /**
  * Returns a new File object representing the file located at 'path'.
  *
- * @param {String} path path of the file
+ * @param {string} path path of the file
  * @return {File} File object representing the file located at the path
  */
 function file(path) {

--- a/docs/Queue.html
+++ b/docs/Queue.html
@@ -164,7 +164,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -199,7 +199,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -238,10 +238,10 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 |
 
-<span class="param-type">Object</span>
+<span class="param-type"><a href="global.html#queueOpts">queueOpts</a></span>
 
 
             
@@ -267,113 +267,7 @@
                 </td>
             
 
-            <td class="description last">
-                <h6>Properties</h6>
-                
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-        <th>Default</th>
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>enableWatchdog</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Boolean</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                    <code>false</code>
-                
-                </td>
-            
-
-            <td class="description last"><p>Will watch for stuck jobs</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>logger</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Console</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                </td>
-            
-
-            <td class="description last"><p>Read more here :  https://github.com/Automattic/kue#unstable-redis-connections</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-            </td>
+            <td class="description last"><p>enableWatchdog or opts object (default = {})<br>Read more here :  https://github.com/Automattic/kue#unstable-redis-connections</p></td>
         </tr>
 
     
@@ -419,7 +313,7 @@
 
     
 
-    <h4 class="name" id=".exit"><span class="type-signature">(async, static) </span>exit<span class="signature">(timeout<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Boolean}</span></h4>
+    <h4 class="name" id=".exit"><span class="type-signature">(async, static) </span>exit<span class="signature">(timeout<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {boolean}</span></h4>
 
     
 
@@ -431,7 +325,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line545">line 545</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line549">line 549</a>
     </li></ul></dd>
     
 
@@ -519,7 +413,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -576,7 +470,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
     </dd>
@@ -590,7 +484,7 @@
 
     
 
-    <h4 class="name" id=".getCount"><span class="type-signature">(async, static) </span>getCount<span class="signature">(queue, jobType)</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id=".getCount"><span class="type-signature">(async, static) </span>getCount<span class="signature">(queue, jobType)</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -602,7 +496,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line373">line 373</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line377">line 377</a>
     </li></ul></dd>
     
 
@@ -686,7 +580,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -709,7 +603,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -754,7 +648,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -875,7 +769,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -914,7 +808,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -979,7 +873,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line527">line 527</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line531">line 531</a>
     </li></ul></dd>
     
 
@@ -1063,7 +957,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -1157,7 +1051,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line508">line 508</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line512">line 512</a>
     </li></ul></dd>
     
 
@@ -1241,7 +1135,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -1300,7 +1194,7 @@
 
     
 
-    <h4 class="name" id="activeJobs"><span class="type-signature">(async) </span>activeJobs<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="activeJobs"><span class="type-signature">(async) </span>activeJobs<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -1312,7 +1206,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line426">line 426</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line430">line 430</a>
     </li></ul></dd>
     
 
@@ -1392,7 +1286,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -1418,7 +1312,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line218">line 218</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line222">line 222</a>
     </li></ul></dd>
     
 
@@ -1651,7 +1545,7 @@
 
     
 
-    <h4 class="name" id="addJob"><span class="type-signature">(async) </span>addJob<span class="signature">(input, opts)</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="addJob"><span class="type-signature">(async) </span>addJob<span class="signature">(input, opts)</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -1663,7 +1557,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line134">line 134</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line138">line 138</a>
     </li></ul></dd>
     
 
@@ -1815,7 +1709,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -1841,7 +1735,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line278">line 278</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line282">line 282</a>
     </li></ul></dd>
     
 
@@ -1964,7 +1858,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -2029,7 +1923,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line474">line 474</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line478">line 478</a>
     </li></ul></dd>
     
 
@@ -2117,7 +2011,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -2170,7 +2064,7 @@
 
     
 
-    <h4 class="name" id="completedJobs"><span class="type-signature">(async) </span>completedJobs<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="completedJobs"><span class="type-signature">(async) </span>completedJobs<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -2182,7 +2076,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line402">line 402</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line406">line 406</a>
     </li></ul></dd>
     
 
@@ -2262,7 +2156,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -2276,7 +2170,7 @@
 
     
 
-    <h4 class="name" id="delayedJobs"><span class="type-signature">(async) </span>delayedJobs<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="delayedJobs"><span class="type-signature">(async) </span>delayedJobs<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -2288,7 +2182,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line418">line 418</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line422">line 422</a>
     </li></ul></dd>
     
 
@@ -2368,7 +2262,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -2394,7 +2288,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line484">line 484</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line488">line 488</a>
     </li></ul></dd>
     
 
@@ -2482,7 +2376,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -2535,7 +2429,7 @@
 
     
 
-    <h4 class="name" id="failedJobs"><span class="type-signature">(async) </span>failedJobs<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="failedJobs"><span class="type-signature">(async) </span>failedJobs<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -2547,7 +2441,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line410">line 410</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line414">line 414</a>
     </li></ul></dd>
     
 
@@ -2627,7 +2521,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -2641,7 +2535,7 @@
 
     
 
-    <h4 class="name" id="inactiveJobs"><span class="type-signature">(async) </span>inactiveJobs<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="inactiveJobs"><span class="type-signature">(async) </span>inactiveJobs<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -2653,7 +2547,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line385">line 385</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line389">line 389</a>
     </li></ul></dd>
     
 
@@ -2733,7 +2627,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -2759,7 +2653,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line338">line 338</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line342">line 342</a>
     </li></ul></dd>
     
 
@@ -2847,7 +2741,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -2900,7 +2794,7 @@
 
     
 
-    <h4 class="name" id="pendingJobs"><span class="type-signature"></span>pendingJobs<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id="pendingJobs"><span class="type-signature"></span>pendingJobs<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -2912,7 +2806,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line393">line 393</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line397">line 397</a>
     </li></ul></dd>
     
 
@@ -2992,7 +2886,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -3018,7 +2912,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line457">line 457</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line461">line 461</a>
     </li></ul></dd>
     
 
@@ -3173,7 +3067,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line357">line 357</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line361">line 361</a>
     </li></ul></dd>
     
 
@@ -3257,7 +3151,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line228">line 228</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line232">line 232</a>
     </li></ul></dd>
     
 
@@ -3341,7 +3235,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -3390,7 +3284,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line236">line 236</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line240">line 240</a>
     </li></ul></dd>
     
 
@@ -3474,7 +3368,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -3523,7 +3417,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line262">line 262</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line266">line 266</a>
     </li></ul></dd>
     
 
@@ -3607,7 +3501,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -3656,7 +3550,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line253">line 253</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line257">line 257</a>
     </li></ul></dd>
     
 
@@ -3740,7 +3634,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -3789,7 +3683,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line245">line 245</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line249">line 249</a>
     </li></ul></dd>
     
 
@@ -3873,7 +3767,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             

--- a/docs/Queue.js.html
+++ b/docs/Queue.js.html
@@ -115,8 +115,8 @@ class Queue {
 
 	/**
 	 * Initialise the redis connection
-	 * @param {Object} [redis={port: 6379, host: '127.0.0.1'}] Redis connection settings object
-	 * @param {Boolean} [enableWatchdog=false] Will watch for stuck jobs due to any connection issues
+	 * @param {object} [redis={port: 6379, host: '127.0.0.1'}] Redis connection settings object
+	 * @param {boolean} [enableWatchdog=false] Will watch for stuck jobs due to any connection issues
 	 * @see https://github.com/Automattic/kue#unstable-redis-connections
 	 */
 	static init(redis, enableWatchdog) {
@@ -134,14 +134,18 @@ class Queue {
 	}
 
 	/**
+	 * @typedef {object} queueOpts
+	 * @property {boolean} [enableWatchdog=false] Will watch for stuck jobs default: false
+	 * @property {Console} [logger] default logs to console
+	 */
+
+	/**
 	 * Create a new Queue
 	 * The redis and enableWatchdog settings are required only the first time to init
 	 * Can also be set beforehand by calling Queue.init()
-	 * @param {String} name Name of the queue
-	 * @param {Object} [redis={port: 6379, host: '127.0.0.1'}] Redis connection settings object
-	 * @param {Boolean|Object} [options={}]
-	 * @param {Boolean} [options.enableWatchdog=false] Will watch for stuck jobs
-	 * @param {Console} [options.logger]
+	 * @param {string} name Name of the queue
+	 * @param {object} [redis={port: 6379, host: '127.0.0.1'}] Redis connection settings object
+	 * @param {boolean|queueOpts} [options={}] enableWatchdog or opts object (default = {})
 	 * Read more here :  https://github.com/Automattic/kue#unstable-redis-connections
 	 */
 	constructor(name, redis = {port: 6379, host: '127.0.0.1'}, options = {}) {
@@ -160,21 +164,21 @@ class Queue {
 
 
 	/**
-	 * @typedef {Object} addOpts
-	 * @property {Number|String} [priority=0] Priority of the job, lower number is better
+	 * @typedef {object} addOpts
+	 * @property {number|string} [priority=0] Priority of the job, lower number is better
 	 * Options are : low: 10, normal: 0, medium: -5, high: -10, critical: -15 | Or any integer
-	 * @property {Number} [attempts] Number of attempts
-	 * @property {Number} [delay] Delay in between jobs
-	 * @property {Number} [ttl] Time to live for job
-	 * @property {Boolean} [removeOnComplete] Remove job on completion
-	 * @property {Boolean} [noFailure] Mark job as complete even if it fails
+	 * @property {number} [attempts] Number of attempts
+	 * @property {number} [delay] Delay in between jobs
+	 * @property {number} [ttl] Time to live for job
+	 * @property {boolean} [removeOnComplete] Remove job on completion
+	 * @property {boolean} [noFailure] Mark job as complete even if it fails
 	 */
 
 	/**
 	 * Add a job to the Queue
 	 * @param {*} input Job data
 	 * @param {addOpts} opts
-	 * @return {Number} The ID of the job created
+	 * @return {number} The ID of the job created
 	 */
 	async addJob(input, {
 		priority = 0,
@@ -268,7 +272,7 @@ class Queue {
 
 	/**
 	 * Set default number of retry attempts for any job added later
-	 * @param {Number} attempts Number of attempts (>= 0), default = 1
+	 * @param {number} attempts Number of attempts (>= 0), default = 1
 	 */
 	setAttempts(attempts) {
 		this.attempts = attempts;
@@ -276,7 +280,7 @@ class Queue {
 
 	/**
 	 * Set delay b/w successive jobs for any job added later
-	 * @param {Number} delay Delay b/w jobs, milliseconds, default = 0
+	 * @param {number} delay Delay b/w jobs, milliseconds, default = 0
 	 */
 	setDelay(delay) {
 		this.delay = delay;
@@ -285,7 +289,7 @@ class Queue {
 	/**
 	 * Set default TTL (time to live) for new jobs added from now on,
 	 * will fail job if not completed in TTL time
-	 * @param {Number} ttl Time in milliseconds, infinite when 0. default = 0
+	 * @param {number} ttl Time in milliseconds, infinite when 0. default = 0
 	 */
 	setTTL(ttl) {
 		this.ttl = ttl;
@@ -293,7 +297,7 @@ class Queue {
 
 	/**
 	 * Sets default removeOnComplete for any job added to this Queue from now on
-	 * @param {Boolean} removeOnComplete default = false
+	 * @param {boolean} removeOnComplete default = false
 	 */
 	setRemoveOnCompletion(removeOnComplete) {
 		this.removeOnComplete = removeOnComplete;
@@ -302,7 +306,7 @@ class Queue {
 	/**
 	 * Sets default noFailure for any job added to this Queue from now on.
 	 * This will mark the job complete even if it fails when true
-	 * @param {Boolean} noFailure default = false
+	 * @param {boolean} noFailure default = false
 	 */
 	setNoFailure(noFailure) {
 		this.noFailure = noFailure;
@@ -318,7 +322,7 @@ class Queue {
 	/**
 	 * Attach a processor to the Queue which will keep getting jobs as it completes them
 	 * @param {processorCallback} processor Function to be called to process the job data
-	 * @param {Number} [concurrency=1] The number of jobs this processor can handle parallely
+	 * @param {number} [concurrency=1] The number of jobs this processor can handle parallely
 	 */
 	async addProcessor(processor, concurrency = 1) {
 		if (Queue.queues[this.name].processorAdded) {
@@ -378,7 +382,7 @@ class Queue {
 	/**
 	 * Pause Queue processing
 	 * Gives timeout time to all workers to complete their current jobs then stops them
-	 * @param {Number} [timeout=5000] Time to complete current jobs in ms
+	 * @param {number} [timeout=5000] Time to complete current jobs in ms
 	 */
 	async pauseProcessor(timeout = 5000) {
 		if (!Queue.queues[this.name].processorAdded) throw new Error('No processor present');
@@ -411,9 +415,9 @@ class Queue {
 
 	/**
 	 * Return count of jobs in Queue of JobType
-	 * @param {String} queue Queue name
-	 * @param {String} jobType One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
-	 * @return {Number} count
+	 * @param {string} queue Queue name
+	 * @param {string} jobType One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
+	 * @return {number} count
 	 */
 	static async getCount(queue, jobType) {
 		return new Promise((resolve, reject) => {
@@ -425,7 +429,7 @@ class Queue {
 	}
 	/**
 	 * Return count of inactive jobs in Queue
-	 * @return {Number} inactiveCount
+	 * @return {number} inactiveCount
 	 */
 	async inactiveJobs() {
 		return Queue.getCount(this.name, 'inactive');
@@ -433,7 +437,7 @@ class Queue {
 
 	/**
 	 * Alias for inactiveJobs
- 	 * @return {Number} inactiveCount
+ 	 * @return {number} inactiveCount
 	 */
 	pendingJobs() {
 		return this.inactiveJobs();
@@ -442,7 +446,7 @@ class Queue {
 	/**
 	 * Return count of completed jobs in Queue
 	 * Might return 0 if removeOnComplete was true
-	 * @return {Number} completeCount
+	 * @return {number} completeCount
 	 */
 	async completedJobs() {
 		return Queue.getCount(this.name, 'complete');
@@ -450,7 +454,7 @@ class Queue {
 
 	/**
 	 * Return count of failed jobs in Queue
-	 * @return {Number} failedCount
+	 * @return {number} failedCount
 	 */
 	async failedJobs() {
 		return Queue.getCount(this.name, 'failed');
@@ -458,7 +462,7 @@ class Queue {
 
 	/**
 	 * Return count of delayed jobs in Queue
-	 * @return {Number} delayedCount
+	 * @return {number} delayedCount
 	 */
 	async delayedJobs() {
 		return Queue.getCount(this.name, 'delayed');
@@ -466,7 +470,7 @@ class Queue {
 
 	/**
 	 * Return count of active jobs in Queue
-	 * @return {Number} activeCount
+	 * @return {number} activeCount
 	 */
 	async activeJobs() {
 		return Queue.getCount(this.name, 'active');
@@ -474,23 +478,23 @@ class Queue {
 
 	/**
 	 * Internal data object
-	 * @typedef {Object} internalData
+	 * @typedef {object} internalData
 	 * @property {*} input Input data given to job
-	 * @property {Object} options Internal options used to set noFailure and extra properties
+	 * @property {object} options Internal options used to set noFailure and extra properties
 	 */
 
 	/**
 	 * Job status object.
-	 * @typedef {Object} jobDetails
-	 * @property {Number} id
-	 * @property {String} type Name of the Queue
+	 * @typedef {object} jobDetails
+	 * @property {number} id
+	 * @property {string} type Name of the Queue
 	 * @property {internalData} data Internal data object, includes input and options
 	 * @property {*} result Result of the processor callback
-	 * @property {String} state One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
+	 * @property {string} state One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
 	 * @property {*} error
-	 * @property {Number} created_at unix time stamp
-	 * @property {Number} updated_at unix time stamp
-	 * @property {Object} attempts Attempts Object
+	 * @property {number} created_at unix time stamp
+	 * @property {number} updated_at unix time stamp
+	 * @property {object} attempts Attempts Object
 	 */
 
 	/**
@@ -514,7 +518,7 @@ class Queue {
 	/**
 	 * Cleanup function to be called during startup,
 	 * resets active jobs older than specified time
-	 * @param {Number} [olderThan=5000] Time in milliseconds, default = 5000
+	 * @param {number} [olderThan=5000] Time in milliseconds, default = 5000
 	 */
 	async cleanup(olderThan = 5000) {
 		const n = await Queue.getCount(this.name, 'active');
@@ -524,7 +528,7 @@ class Queue {
 	/**
 	 * Removes any old jobs from queue
 	 * older than specified time
-	 * @param {Number} [olderThan=3600000] Time in milliseconds, default = 3600000 (1 hr)
+	 * @param {number} [olderThan=3600000] Time in milliseconds, default = 3600000 (1 hr)
 	 */
 	async delete(olderThan = 3600000) {
 		const completed = await this.completedJobs();
@@ -547,7 +551,7 @@ class Queue {
 
 	/**
 	 * Function to query the status of a job
-	 * @param {Number} jobId Job id for which status info is required
+	 * @param {number} jobId Job id for which status info is required
 	 * @return {jobDetails} Object full of job details like state, time, attempts, etc.
 	 */
 	static async status(jobId) {
@@ -565,7 +569,7 @@ class Queue {
 
 	/**
 	 * Manualy process a specific Job. Returns existing result if job already processed
-	 * @param {Number} jobId Id of the job to be processed
+	 * @param {number} jobId Id of the job to be processed
 	 * @param {processorCallback} processor Function to be called to process the job data, without ctx
 	 * @return {jobDetails} Result of processor function and job object of completed job
 	 */
@@ -584,8 +588,8 @@ class Queue {
 	/**
 	 * Function shuts down the Queue gracefully.
 	 * Waits for active jobs to complete until timeout, then marks them failed.
-	 * @param {Number} [timeout=10000] Time in milliseconds, default = 10000
-	 * @return {Boolean}
+	 * @param {number} [timeout=10000] Time in milliseconds, default = 10000
+	 * @return {boolean}
 	 */
 	static async exit(timeout = 10000) {
 		return new Promise((resolve) => {

--- a/docs/RedisCache.html
+++ b/docs/RedisCache.html
@@ -1337,7 +1337,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             

--- a/docs/RedisCache.js.html
+++ b/docs/RedisCache.js.html
@@ -743,7 +743,7 @@ class RedisCache {
 
 	/**
 	 * Return a global instance of Redis cache
-	 * @param {Object} redis redis redisConf
+	 * @param {object} redis redis redisConf
 	 * @return {RedisCache}
 	 */
 	static globalCache(redis) {

--- a/docs/Str.html
+++ b/docs/Str.html
@@ -1478,7 +1478,7 @@ Str.isVowel('ae') // => false</code></pre>
 
     
 
-    <h4 class="name" id=".rot13"><span class="type-signature">(static) </span>rot13<span class="signature">(str)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".rot13"><span class="type-signature">(static) </span>rot13<span class="signature">(str)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -1574,7 +1574,7 @@ Str.isVowel('ae') // => false</code></pre>
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1619,7 +1619,7 @@ Str.isVowel('ae') // => false</code></pre>
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -1633,7 +1633,7 @@ Str.isVowel('ae') // => false</code></pre>
 
     
 
-    <h4 class="name" id=".rot47"><span class="type-signature">(static) </span>rot47<span class="signature">(str)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".rot47"><span class="type-signature">(static) </span>rot47<span class="signature">(str)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -1729,7 +1729,7 @@ Str.isVowel('ae') // => false</code></pre>
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1774,7 +1774,7 @@ Str.isVowel('ae') // => false</code></pre>
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -2565,7 +2565,7 @@ Str.isVowel('ae') // => false</code></pre>
 
     
 
-    <h4 class="name" id=".tryParseJson"><span class="type-signature">(static) </span>tryParseJson<span class="signature">(str)</span><span class="type-signature"> &rarr; {Object|null}</span></h4>
+    <h4 class="name" id=".tryParseJson"><span class="type-signature">(static) </span>tryParseJson<span class="signature">(str)</span><span class="type-signature"> &rarr; {object|null}</span></h4>
 
     
 
@@ -2702,7 +2702,7 @@ Str.isVowel('ae') // => false</code></pre>
     </dt>
     <dd>
         
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 |
 
 <span class="param-type">null</span>

--- a/docs/Str_Str.js.html
+++ b/docs/Str_Str.js.html
@@ -257,8 +257,8 @@ function spaceClean(str) {
  * Rotate a string by 13 characters
  *
  * @memberof Str
- * @param {String} str the string to be rotated
- * @return {String} rotated string
+ * @param {string} str the string to be rotated
+ * @return {string} rotated string
  */
 function rot13(str) {
 	const s = [];
@@ -282,8 +282,8 @@ function rot13(str) {
  * Rotate a string by 47 characters
  *
  * @memberof Str
- * @param {String} str the string to be rotated
- * @return {String} rotated string
+ * @param {string} str the string to be rotated
+ * @return {string} rotated string
  */
 function rot47(str) {
 	const s = [];
@@ -305,7 +305,7 @@ function rot47(str) {
  *
  * @memberof Str
  * @param {string} str
- * @return {Object|null}
+ * @return {object|null}
  */
 function tryParseJson(str) {
 	try {

--- a/docs/System.html
+++ b/docs/System.html
@@ -63,2691 +63,6 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_gracefulServerShutdown.js.html">System/gracefulServerShutdown.js</a>, <a href="System_gracefulServerShutdown.js.html#line1">line 1</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-            
-                <div class="description"><p>gracefully shuts downs a http server<br>Partially based on: https://github.com/sebhildebrandt/http-graceful-shutdown<br>LICENSE: MIT</p></div>
-            
-
-            
-        
-        </div>
-    
-
-    
-
-    
-
-    
-
-     
-
-    
-
-    
-
-    
-        <h3 class="subsection-title">Methods</h3>
-
-        
-            
-
-    
-
-    <h4 class="name" id=".exec"><span class="type-signature">(static) </span>exec<span class="signature">(command, options)</span><span class="type-signature"> &rarr; {Promise.&lt;<a href="global.html#processObject">processObject</a>>}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line78">line 78</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>Execute the given command in a shell.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>command</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>options</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>options object<br>options: {timeout (in ms), cwd, uid, gid, env (object), shell (eg. /bin/sh), encoding}</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Promise.&lt;<a href="global.html#processObject">processObject</a>></span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".execFile"><span class="type-signature">(static) </span>execFile<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {Promise.&lt;<a href="global.html#processObject">processObject</a>>}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line88">line 88</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>Similar to exec but instead executes a given file</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>args</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Array.&lt;any></span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                    &lt;repeatable><br>
-                
-                </td>
-            
-
-            
-
-            <td class="description last"></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Promise.&lt;<a href="global.html#processObject">processObject</a>></span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".execFileOut"><span class="type-signature">(async, static) </span>execFileOut<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {String}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line110">line 110</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>execute a file and return its output</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>args</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Array.&lt;any></span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                    &lt;repeatable><br>
-                
-                </td>
-            
-
-            
-
-            <td class="description last"></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>output of the file's execution</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">String</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".execOut"><span class="type-signature">(async, static) </span>execOut<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {String}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line99">line 99</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>execute a command and return its output</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>args</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Array.&lt;any></span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                    &lt;repeatable><br>
-                
-                </td>
-            
-
-            
-
-            <td class="description last"></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>output of the command's execution</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">String</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".exit"><span class="type-signature">(static) </span>exit<span class="signature">(code)</span><span class="type-signature"> &rarr; {void}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line277">line 277</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>exit and kill the process gracefully (after completing all onExit handlers)<br>code can be an exit code or a message (string)<br>if a message is given then it will be logged to console before exiting</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>code</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">number</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>exit code or the message to be logged</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">void</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".forceExit"><span class="type-signature">(static) </span>forceExit<span class="signature">(code)</span><span class="type-signature"> &rarr; {void}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line297">line 297</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>force exit the process<br>no onExit handler will run when force exiting a process<br>same as original process.exit (which we override)</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>code</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">number</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>exit code or the message to be logged</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">void</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".getAllUsers"><span class="type-signature">(static) </span>getAllUsers<span class="signature">()</span><span class="type-signature"> &rarr; {Object}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line182">line 182</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>get all users in the system<br>currently gets user info from /etc/passwd</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>object containing info for all users, as username:info pairs</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Object</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".getuid"><span class="type-signature">(static) </span>getuid<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line144">line 144</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>get the uid of the user running current process</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>uid</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Number</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".getUserInfo"><span class="type-signature">(static) </span>getUserInfo<span class="signature">(user)</span><span class="type-signature"> &rarr; {Object}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line156">line 156</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>get user info from username or uid<br>currently gets user info from /etc/passwd</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>user</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">String</span>
-|
-
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>username or uid</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>the user's information</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Object</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".gracefulServerExit"><span class="type-signature">(static) </span>gracefulServerExit<span class="signature">(server, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line398">line 398</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-        <th>Default</th>
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>server</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">*</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                </td>
-            
-
-            <td class="description last"></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>options</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">number</span>
-|
-
-<span class="param-type"><a href="global.html#timeoutOpts">timeoutOpts</a></span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                    <code>{}</code>
-                
-                </td>
-            
-
-            <td class="description last"></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".microtime"><span class="type-signature">(static) </span>microtime<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line239">line 239</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>get current time in microseconds (as double)</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>current time in microseconds</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Number</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".millitime"><span class="type-signature">(static) </span>millitime<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line216">line 216</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>get current time in milliseconds (as double)</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>current time in milliseconds</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Number</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".nanotime"><span class="type-signature">(static) </span>nanotime<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line226">line 226</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>get current time in nanoseconds (as double)</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>current time in nanoseconds</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Number</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".noUmask"><span class="type-signature">(static) </span>noUmask<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line120">line 120</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>turn off umask for the current process</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>the old umask</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">number</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".onExit"><span class="type-signature">(static) </span>onExit<span class="signature">(callback, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Promise.&lt;void>}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line363">line 363</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>Add an exit handler that runs when process receives an exit signal<br>callback can be an async function, process will exit when all handlers have completed</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-        <th>Default</th>
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>callback</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">function</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                </td>
-            
-
-            <td class="description last"><p>function to call on exit</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>options</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">number</span>
-|
-
-<span class="param-type"><a href="global.html#timeoutOpts">timeoutOpts</a></span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                    <code>{}</code>
-                
-                </td>
-            
-
-            <td class="description last"><p>can be {timeout} or a number</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Promise.&lt;void></span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".sleep"><span class="type-signature">(static) </span>sleep<span class="signature">()</span><span class="type-signature"> &rarr; {Promise.&lt;void>}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line249">line 249</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>Sleep for a specified time (in milliseconds)<br>  Example: await System.sleep(2000);</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Promise.&lt;void></span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".tick"><span class="type-signature">(static) </span>tick<span class="signature">()</span><span class="type-signature"> &rarr; {Promise.&lt;void>}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line262">line 262</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>wait till the next event loop cycle<br>this function is useful if we are running a long blocking task<br>and need to make sure that other callbacks can complete.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Promise.&lt;void></span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".time"><span class="type-signature">(static) </span>time<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line206">line 206</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>get current time in seconds</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>current time in seconds</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">Number</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-            
-
-    
-
-    <h4 class="name" id=".yesUmask"><span class="type-signature">(static) </span>yesUmask<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
-
-    
-
-
-
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line130">line 130</a>
-    </li></ul></dd>
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-<div class="description">
-    <p>restores (turns on) the previous umask</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<h5>Returns:</h5>
-
-        
-<div class="param-desc">
-    <p>new umask</p>
-</div>
-
-
-
-<dl class="param-type">
-    <dt>
-        Type
-    </dt>
-    <dd>
-        
-<span class="param-type">number</span>
-
-
-    </dd>
-</dl>
-
-    
-
-
-        
-    
-
-    
-
-    
-</article>
-
-</section>
-
-
-
-
-
-
-
-<section>
-
-<header>
-    
-        <h2>
-        System
-        </h2>
-        
-    
-</header>
-
-<article>
-    
-        <div class="container-overview">
-        
-            
-
-<dl class="details">
-
-    
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
         <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line6">line 6</a>
     </li></ul></dd>
     
@@ -2911,7 +226,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -2934,7 +249,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -3152,7 +467,7 @@
 
     
 
-    <h4 class="name" id=".execFileOut"><span class="type-signature">(async, static) </span>execFileOut<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".execFileOut"><span class="type-signature">(async, static) </span>execFileOut<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -3305,7 +620,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -3319,7 +634,7 @@
 
     
 
-    <h4 class="name" id=".execOut"><span class="type-signature">(async, static) </span>execOut<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {String}</span></h4>
+    <h4 class="name" id=".execOut"><span class="type-signature">(async, static) </span>execOut<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {string}</span></h4>
 
     
 
@@ -3472,7 +787,7 @@
     </dt>
     <dd>
         
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
     </dd>
@@ -3585,7 +900,7 @@
 <span class="param-type">number</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3739,7 +1054,7 @@
 <span class="param-type">number</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -3794,7 +1109,7 @@
 
     
 
-    <h4 class="name" id=".getAllUsers"><span class="type-signature">(static) </span>getAllUsers<span class="signature">()</span><span class="type-signature"> &rarr; {Object}</span></h4>
+    <h4 class="name" id=".getAllUsers"><span class="type-signature">(static) </span>getAllUsers<span class="signature">()</span><span class="type-signature"> &rarr; {object}</span></h4>
 
     
 
@@ -3886,7 +1201,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
     </dd>
@@ -3900,7 +1215,7 @@
 
     
 
-    <h4 class="name" id=".getuid"><span class="type-signature">(static) </span>getuid<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id=".getuid"><span class="type-signature">(static) </span>getuid<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -3992,7 +1307,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -4006,7 +1321,7 @@
 
     
 
-    <h4 class="name" id=".getUserInfo"><span class="type-signature">(static) </span>getUserInfo<span class="signature">(user)</span><span class="type-signature"> &rarr; {Object}</span></h4>
+    <h4 class="name" id=".getUserInfo"><span class="type-signature">(static) </span>getUserInfo<span class="signature">(user)</span><span class="type-signature"> &rarr; {object}</span></h4>
 
     
 
@@ -4102,10 +1417,10 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 |
 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -4150,7 +1465,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
     </dd>
@@ -4351,7 +1666,7 @@
 
     
 
-    <h4 class="name" id=".microtime"><span class="type-signature">(static) </span>microtime<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id=".microtime"><span class="type-signature">(static) </span>microtime<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -4443,7 +1758,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -4457,7 +1772,7 @@
 
     
 
-    <h4 class="name" id=".millitime"><span class="type-signature">(static) </span>millitime<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id=".millitime"><span class="type-signature">(static) </span>millitime<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -4549,7 +1864,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -4563,7 +1878,7 @@
 
     
 
-    <h4 class="name" id=".nanotime"><span class="type-signature">(static) </span>nanotime<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id=".nanotime"><span class="type-signature">(static) </span>nanotime<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -4655,7 +1970,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
     </dd>
@@ -5188,7 +2503,7 @@
 
     
 
-    <h4 class="name" id=".time"><span class="type-signature">(static) </span>time<span class="signature">()</span><span class="type-signature"> &rarr; {Number}</span></h4>
+    <h4 class="name" id=".time"><span class="type-signature">(static) </span>time<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
 
     
 
@@ -5280,7 +2595,2692 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".yesUmask"><span class="type-signature">(static) </span>yesUmask<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line130">line 130</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>restores (turns on) the previous umask</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>new umask</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">number</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+    
+
+    
+
+    
+</article>
+
+</section>
+
+
+
+
+
+
+
+<section>
+
+<header>
+    
+        <h2>
+        System
+        </h2>
+        
+    
+</header>
+
+<article>
+    
+        <div class="container-overview">
+        
+            
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_gracefulServerShutdown.js.html">System/gracefulServerShutdown.js</a>, <a href="System_gracefulServerShutdown.js.html#line1">line 1</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+            
+                <div class="description"><p>gracefully shuts downs a http server<br>Partially based on: https://github.com/sebhildebrandt/http-graceful-shutdown<br>LICENSE: MIT</p></div>
+            
+
+            
+        
+        </div>
+    
+
+    
+
+    
+
+    
+
+     
+
+    
+
+    
+
+    
+        <h3 class="subsection-title">Methods</h3>
+
+        
+            
+
+    
+
+    <h4 class="name" id=".exec"><span class="type-signature">(static) </span>exec<span class="signature">(command, options)</span><span class="type-signature"> &rarr; {Promise.&lt;<a href="global.html#processObject">processObject</a>>}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line78">line 78</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>Execute the given command in a shell.</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>command</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>options</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">object</span>
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"><p>options object<br>options: {timeout (in ms), cwd, uid, gid, env (object), shell (eg. /bin/sh), encoding}</p></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">Promise.&lt;<a href="global.html#processObject">processObject</a>></span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".execFile"><span class="type-signature">(static) </span>execFile<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {Promise.&lt;<a href="global.html#processObject">processObject</a>>}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line88">line 88</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>Similar to exec but instead executes a given file</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+        <th>Attributes</th>
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>args</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">Array.&lt;any></span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+
+                
+
+                
+                    &lt;repeatable><br>
+                
+                </td>
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">Promise.&lt;<a href="global.html#processObject">processObject</a>></span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".execFileOut"><span class="type-signature">(async, static) </span>execFileOut<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {string}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line110">line 110</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>execute a file and return its output</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+        <th>Attributes</th>
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>args</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">Array.&lt;any></span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+
+                
+
+                
+                    &lt;repeatable><br>
+                
+                </td>
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>output of the file's execution</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">string</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".execOut"><span class="type-signature">(async, static) </span>execOut<span class="signature">(&hellip;args)</span><span class="type-signature"> &rarr; {string}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line99">line 99</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>execute a command and return its output</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+        <th>Attributes</th>
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>args</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">Array.&lt;any></span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+
+                
+
+                
+                    &lt;repeatable><br>
+                
+                </td>
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>output of the command's execution</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">string</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".exit"><span class="type-signature">(static) </span>exit<span class="signature">(code)</span><span class="type-signature"> &rarr; {void}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line277">line 277</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>exit and kill the process gracefully (after completing all onExit handlers)<br>code can be an exit code or a message (string)<br>if a message is given then it will be logged to console before exiting</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>code</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">number</span>
+|
+
+<span class="param-type">string</span>
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"><p>exit code or the message to be logged</p></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">void</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".forceExit"><span class="type-signature">(static) </span>forceExit<span class="signature">(code)</span><span class="type-signature"> &rarr; {void}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line297">line 297</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>force exit the process<br>no onExit handler will run when force exiting a process<br>same as original process.exit (which we override)</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>code</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">number</span>
+|
+
+<span class="param-type">string</span>
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"><p>exit code or the message to be logged</p></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">void</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".getAllUsers"><span class="type-signature">(static) </span>getAllUsers<span class="signature">()</span><span class="type-signature"> &rarr; {object}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line182">line 182</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>get all users in the system<br>currently gets user info from /etc/passwd</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>object containing info for all users, as username:info pairs</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">object</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".getuid"><span class="type-signature">(static) </span>getuid<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line144">line 144</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>get the uid of the user running current process</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>uid</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">number</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".getUserInfo"><span class="type-signature">(static) </span>getUserInfo<span class="signature">(user)</span><span class="type-signature"> &rarr; {object}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line156">line 156</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>get user info from username or uid<br>currently gets user info from /etc/passwd</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>user</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+|
+
+<span class="param-type">number</span>
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"><p>username or uid</p></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>the user's information</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">object</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".gracefulServerExit"><span class="type-signature">(static) </span>gracefulServerExit<span class="signature">(server, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line398">line 398</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+        <th>Attributes</th>
+        
+
+        
+        <th>Default</th>
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>server</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">*</span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                </td>
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>options</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">number</span>
+|
+
+<span class="param-type"><a href="global.html#timeoutOpts">timeoutOpts</a></span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+                    &lt;optional><br>
+                
+
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                    <code>{}</code>
+                
+                </td>
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".microtime"><span class="type-signature">(static) </span>microtime<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line239">line 239</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>get current time in microseconds (as double)</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>current time in microseconds</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">number</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".millitime"><span class="type-signature">(static) </span>millitime<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line216">line 216</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>get current time in milliseconds (as double)</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>current time in milliseconds</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">number</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".nanotime"><span class="type-signature">(static) </span>nanotime<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line226">line 226</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>get current time in nanoseconds (as double)</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>current time in nanoseconds</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">number</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".noUmask"><span class="type-signature">(static) </span>noUmask<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line120">line 120</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>turn off umask for the current process</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>the old umask</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">number</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".onExit"><span class="type-signature">(static) </span>onExit<span class="signature">(callback, options<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Promise.&lt;void>}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line363">line 363</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>Add an exit handler that runs when process receives an exit signal<br>callback can be an async function, process will exit when all handlers have completed</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+        <th>Attributes</th>
+        
+
+        
+        <th>Default</th>
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>callback</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">function</span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                </td>
+            
+
+            <td class="description last"><p>function to call on exit</p></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>options</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">number</span>
+|
+
+<span class="param-type"><a href="global.html#timeoutOpts">timeoutOpts</a></span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+                    &lt;optional><br>
+                
+
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                    <code>{}</code>
+                
+                </td>
+            
+
+            <td class="description last"><p>can be {timeout} or a number</p></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">Promise.&lt;void></span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".sleep"><span class="type-signature">(static) </span>sleep<span class="signature">()</span><span class="type-signature"> &rarr; {Promise.&lt;void>}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line249">line 249</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>Sleep for a specified time (in milliseconds)<br>  Example: await System.sleep(2000);</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">Promise.&lt;void></span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".tick"><span class="type-signature">(static) </span>tick<span class="signature">()</span><span class="type-signature"> &rarr; {Promise.&lt;void>}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line262">line 262</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>wait till the next event loop cycle<br>this function is useful if we are running a long blocking task<br>and need to make sure that other callbacks can complete.</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">Promise.&lt;void></span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
+    <h4 class="name" id=".time"><span class="type-signature">(static) </span>time<span class="signature">()</span><span class="type-signature"> &rarr; {number}</span></h4>
+
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="System_System.js.html">System/System.js</a>, <a href="System_System.js.html#line206">line 206</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>get current time in seconds</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>current time in seconds</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">number</span>
 
 
     </dd>

--- a/docs/System_System.js.html
+++ b/docs/System_System.js.html
@@ -115,8 +115,8 @@ function execWrapper(method, args) {
 /**
  * Execute the given command in a shell.
  * @memberof System
- * @param {String} command
- * @param {Object} options options object
+ * @param {string} command
+ * @param {object} options options object
  * options: {timeout (in ms), cwd, uid, gid, env (object), shell (eg. /bin/sh), encoding}
  * @return {Promise&lt;processObject>}
  */
@@ -139,7 +139,7 @@ function execFile(...args) {
  *
  * @memberof System
  * @param {Array&lt;any>} args
- * @return {String} output of the command's execution
+ * @return {string} output of the command's execution
  */
 async function execOut(...args) {
 	return (await exec.apply(this, args)).stdout.toString();
@@ -150,7 +150,7 @@ async function execOut(...args) {
  *
  * @memberof System
  * @param {Array&lt;any>} args
- * @return {String} output of the file's execution
+ * @return {string} output of the file's execution
  */
 async function execFileOut(...args) {
 	return (await execFile.apply(this, args)).stdout.toString();
@@ -184,7 +184,7 @@ function yesUmask() {
  * get the uid of the user running current process
  *
  * @memberof System
- * @return {Number}  uid
+ * @return {number}  uid
  */
 function getuid() {
 	return process.getuid();
@@ -195,8 +195,8 @@ function getuid() {
  * currently gets user info from /etc/passwd
  *
  * @memberof System
- * @param  {String|Number} user username or uid
- * @return {Object}             the user's information
+ * @param  {string|number} user username or uid
+ * @return {object}             the user's information
  */
 function getUserInfo(user) {
 	user = (user === undefined) ? process.getuid() : user;
@@ -222,7 +222,7 @@ function getUserInfo(user) {
  * currently gets user info from /etc/passwd
  *
  * @memberof System
- * @return {Object}  object containing info for all users, as username:info pairs
+ * @return {object}  object containing info for all users, as username:info pairs
  */
 function getAllUsers() {
 	return new Promise((resolve, reject) => {
@@ -246,7 +246,7 @@ function getAllUsers() {
  * get current time in seconds
  *
  * @memberof System
- * @return {Number}  current time in seconds
+ * @return {number}  current time in seconds
  */
 function time() {
 	return Math.floor(Date.now() / 1000);
@@ -256,7 +256,7 @@ function time() {
  * get current time in milliseconds (as double)
  *
  * @memberof System
- * @return {Number}  current time in milliseconds
+ * @return {number}  current time in milliseconds
  */
 function millitime() {
 	return (Date.now() / 1000);
@@ -266,7 +266,7 @@ function millitime() {
  * get current time in nanoseconds (as double)
  *
  * @memberof System
- * @return {Number}  current time in nanoseconds
+ * @return {number}  current time in nanoseconds
  */
 function nanotime() {
 	const hrtime = process.hrtime();
@@ -279,7 +279,7 @@ function nanotime() {
  * get current time in microseconds (as double)
  *
  * @memberof System
- * @return {Number}  current time in microseconds
+ * @return {number}  current time in microseconds
  */
 function microtime() {
 	return nanotime();
@@ -316,7 +316,7 @@ function tick() {
  * if a message is given then it will be logged to console before exiting
  *
  * @memberof System
- * @param {number|String} code exit code or the message to be logged
+ * @param {number|string} code exit code or the message to be logged
  * @return {void}
  */
 function exit(code) {
@@ -336,7 +336,7 @@ function exit(code) {
  * same as original process.exit (which we override)
  *
  * @memberof System
- * @param {number|String} code exit code or the message to be logged
+ * @param {number|string} code exit code or the message to be logged
  * @return {void}
  */
 function forceExit(code) {

--- a/docs/cfg.js.html
+++ b/docs/cfg.js.html
@@ -80,7 +80,7 @@ function merge(conf, confPrivate) {
 
 /**
  * Reads a config value
- * @param {String} key key to read, can be nested like `a.b.c`
+ * @param {string} key key to read, can be nested like `a.b.c`
  * @param {*} defaultValue value to return if key is not found
  * @return {any}
  */
@@ -121,7 +121,7 @@ function readDefaultConfigFiles() {
 	readEnvVariables();
 }
 /**
- * @memberOf config
+ * @memberof config
  * @param {string} key
  * @param {any} defaultValue
  * @return {any}
@@ -132,7 +132,7 @@ cfg.get = function (key, defaultValue) {
 
 /** set values in global config
  * you can also give key as an object to assign all key values from it
- * @memberOf config
+ * @memberof config
  * @return {null}
  */
 cfg.set = function (key, value) {
@@ -155,7 +155,7 @@ cfg.set = function (key, value) {
  * set values in global config with an object to assign all key values from it
  * if a key already exists then it is merged with new value
  * if obj is not an Object then nothing happens
- * @memberOf config
+ * @memberof config
  * @return {null}
  */
 cfg.merge = function (obj) {
@@ -175,7 +175,7 @@ cfg.merge = function (obj) {
  * set values in global config with an object to assign all key values from it
  * if a key already exists then it is assigned with new value
  * if obj is not an Object then nothing happens
- * @memberOf config
+ * @memberof config
  * @return {null}
  */
 cfg.assign = function (obj) {
@@ -191,7 +191,7 @@ cfg.assign = function (obj) {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {void}
  */
 cfg.delete = function (key) {
@@ -201,7 +201,7 @@ cfg.delete = function (key) {
 
 /**
  * read config from a file, and merge with existing config
- * @memberOf config
+ * @memberof config
  * @param {string} file path of the file to read (only absolute paths)
  * @param {object} options
  * 	options = {ignoreErrors = ignore all errors, ignoreNotFound = ignore if file not found}
@@ -234,8 +234,8 @@ cfg.file = function (file, options = {}) {
 
 /**
  * read the file specified by the key, and then cache it
- * @memberOf config
- * @param {String} key
+ * @memberof config
+ * @param {string} key
  * @return {any} value
  */
 cfg.read = function (key) {
@@ -260,7 +260,7 @@ cfg.read = function (key) {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isProduction = function () {
@@ -268,7 +268,7 @@ cfg.isProduction = function () {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isStaging = function () {
@@ -277,7 +277,7 @@ cfg.isStaging = function () {
 
 /**
  * Returns true if env is production or staging
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isProductionLike = function () {
@@ -285,7 +285,7 @@ cfg.isProductionLike = function () {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isTest = function () {
@@ -293,7 +293,7 @@ cfg.isTest = function () {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isDev = function () {

--- a/docs/config.html
+++ b/docs/config.html
@@ -1355,7 +1355,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             

--- a/docs/global.html
+++ b/docs/global.html
@@ -430,7 +430,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -665,7 +665,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="File.js.html">File.js</a>, <a href="File.js.html#line448">line 448</a>
+        <a href="File.js.html">File.js</a>, <a href="File.js.html#line472">line 472</a>
     </li></ul></dd>
     
 
@@ -749,7 +749,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -822,7 +822,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line117">line 117</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line121">line 121</a>
     </li></ul></dd>
     
 
@@ -895,10 +895,10 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 |
 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -935,7 +935,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -970,7 +970,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -1005,7 +1005,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -1040,7 +1040,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -1075,7 +1075,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             
@@ -1115,7 +1115,7 @@
     <ul>
         <li>
             
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
         </li>
@@ -1462,7 +1462,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line430">line 430</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line434">line 434</a>
     </li></ul></dd>
     
 
@@ -1554,7 +1554,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -1586,7 +1586,7 @@
     <ul>
         <li>
             
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
         </li>
@@ -1610,7 +1610,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line437">line 437</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line441">line 441</a>
     </li></ul></dd>
     
 
@@ -1679,7 +1679,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -1702,7 +1702,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1771,7 +1771,7 @@
             <td class="type">
             
                 
-<span class="param-type">String</span>
+<span class="param-type">string</span>
 
 
             
@@ -1817,7 +1817,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -1840,7 +1840,7 @@
             <td class="type">
             
                 
-<span class="param-type">Number</span>
+<span class="param-type">number</span>
 
 
             
@@ -1863,7 +1863,7 @@
             <td class="type">
             
                 
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
             
@@ -1895,7 +1895,7 @@
     <ul>
         <li>
             
-<span class="param-type">Object</span>
+<span class="param-type">object</span>
 
 
         </li>
@@ -2257,7 +2257,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line266">line 266</a>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line270">line 270</a>
     </li></ul></dd>
     
 
@@ -2393,6 +2393,180 @@
 </dl>
 
     
+
+
+            
+                
+<h4 class="name" id="queueOpts">queueOpts</h4>
+
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="Queue.js.html">Queue.js</a>, <a href="Queue.js.html#line91">line 91</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+    <h5 class="subsection-title">Properties:</h5>
+
+    
+
+<table class="props">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+        <th>Attributes</th>
+        
+
+        
+        <th>Default</th>
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>enableWatchdog</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">boolean</span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+                    &lt;optional><br>
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                    <code>false</code>
+                
+                </td>
+            
+
+            <td class="description last"><p>Will watch for stuck jobs default: false</p></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>logger</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">Console</span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+                    &lt;optional><br>
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                </td>
+            
+
+            <td class="description last"><p>default logs to console</p></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+    <h5>Type:</h5>
+    <ul>
+        <li>
+            
+<span class="param-type">object</span>
+
+
+        </li>
+    </ul>
+
+
+
+
 
 
             
@@ -2759,7 +2933,7 @@
             <td class="type">
             
                 
-<span class="param-type">Boolean</span>
+<span class="param-type">boolean</span>
 
 
             

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,7 +145,7 @@ declare module 'sm-utils' {
         static clear(): void;
 
         /**
-         *
+         * 
          * @param key
          * @param fn
          * @param options ttl in ms/timestring('1d 3h') or opts (default: 0)
@@ -171,29 +171,19 @@ declare module 'sm-utils' {
         constructor();
 
         /**
-         * Timeout period for the request in milliseconds
-         */
-        requestTimeout: any;
-
-        /**
-         * Various options (or parameters) defining the Connection
-         */
-        options: any;
-
-        /**
          * Set the url for the connection.
          * @param url self-descriptive
          */
-        url(url: String): Connect;
+        url(url: string): Connect;
 
         /**
-         *
+         * 
          * @param url self-descriptive
          */
-        static url(url: String): Connect;
+        static url(url: string): Connect;
 
         /**
-         *
+         * 
          * @param args
          */
         static newCookieJar(...args: any[]): CookieJar;
@@ -202,50 +192,50 @@ declare module 'sm-utils' {
          * Set or unset the followRedirect option for the connection.
          * @param shouldFollowRedirect boolean representing whether to follow redirect or not
          */
-        followRedirect(shouldFollowRedirect: Boolean): Connect;
+        followRedirect(shouldFollowRedirect: boolean): Connect;
 
         /**
          * Set value of a header parameter for the connection.
          * @param headerName name of the header parameter whose value is to be set
          * @param headerValue value to be set
          */
-        header(headerName: String, headerValue: any): Connect;
+        header(headerName: string, headerValue: any): Connect;
 
         /**
          * Set value of the headers for the connection.
          * @param headers object representing the headers for the connection
          */
-        headers(headers: Object): Connect;
+        headers(headers: object): Connect;
 
         /**
          * Set the body of the connection object.
          * @param body value for body
          * @param contentType string representing the content type of the body
          */
-        body(body: any, contentType?: String): Connect;
+        body(body: any, contentType?: string): Connect;
 
         /**
          * Set the 'Referer' field in the headers.
          * @param referer referer value
          */
-        referer(referer: String): Connect;
+        referer(referer: string): Connect;
 
         /**
          * Set the 'User-Agent' field in the headers.
          * @param userAgent name of the user-agent or its value
          */
-        userAgent(userAgent: String): Connect;
+        userAgent(userAgent: string): Connect;
 
         /**
          * Set the 'Content-Type' field in the headers.
          * @param contentType value for content-type
          */
-        contentType(contentType: String): Connect;
+        contentType(contentType: string): Connect;
 
         /**
          * Returns whether the content-type is JSON or not
          */
-        isJSON(): Boolean;
+        isJSON(): boolean;
 
         /**
          * Sets the value of a cookie.
@@ -257,7 +247,7 @@ declare module 'sm-utils' {
          *        cookie to be set, or the cookies object
          * @param cookieValue cookie value to be set
          */
-        cookie(cookieName: String | Boolean | Object, cookieValue: Object): Connect;
+        cookie(cookieName: string | boolean | object, cookieValue: object): Connect;
 
         /**
          * Sets multiple cookies.
@@ -265,19 +255,19 @@ declare module 'sm-utils' {
          * @param cookies object representing the cookies
          *        and their values as key:value pairs.
          */
-        cookies(cookies: Object | Boolean): Connect;
+        cookies(cookies: object | boolean): Connect;
 
         /**
          * Enable global cookies.
          * @param enableGlobalCookies self-descriptive
          */
-        globalCookies(enableGlobalCookies?: Boolean): Connect;
+        globalCookies(enableGlobalCookies?: boolean): Connect;
 
         /**
          * Set the value of cookie jar based on a file (cookie store).
          * @param fileName name of (or path to) the file
          */
-        cookieFile(fileName: String): Connect;
+        cookieFile(fileName: string): Connect;
 
         /**
          * Set the value of cookie jar.
@@ -289,13 +279,13 @@ declare module 'sm-utils' {
          * Set request timeout.
          * @param timeout timeout value in seconds
          */
-        timeout(timeout: Number): Connect;
+        timeout(timeout: number): Connect;
 
         /**
          * Set request timeout.
          * @param timeoutInMs timeout value in milliseconds
          */
-        timeoutMs(timeoutInMs: Number): Connect;
+        timeoutMs(timeoutInMs: number): Connect;
 
         /**
          * alias for timeoutMs
@@ -310,54 +300,54 @@ declare module 'sm-utils' {
          * @param fieldName name of the field to be set, or the fields object
          * @param fieldValue value to be set
          */
-        field(fieldName: String | Object, fieldValue: any): Connect;
+        field(fieldName: string | object, fieldValue: any): Connect;
 
         /**
          * Set multiple fields.
          * @param fields object representing the field-names and their
          *        values as key:value pairs
          */
-        fields(fields: Object): Connect;
+        fields(fields: object): Connect;
 
         /**
          * Set the request method for the connection.
          * @param method one of the HTTP request methods ('GET', 'PUT', 'POST', etc.)
          */
-        method(method: String): Connect;
+        method(method: string): Connect;
 
         /**
          * Set username and password for authentication.
          * @param username self-descriptive
          * @param password self-descriptive
          */
-        httpAuth(username: String, password: String): Connect;
+        httpAuth(username: string, password: string): Connect;
 
         /**
          * Set proxy address (or options).
          * @param proxy proxy address, or object representing proxy options
          */
-        proxy(proxy: String | Object): Connect;
+        proxy(proxy: string | object): Connect;
 
         /**
          * Set address and port for an http proxy.
          * @param proxyAddress self-descriptive
          * @param proxyPort self-descriptive
          */
-        httpProxy(proxyAddress: String, proxyPort: Number): Connect;
+        httpProxy(proxyAddress: string, proxyPort: number): Connect;
 
         /**
          * Set address and port for a socks proxy.
          * @param proxyAddress self-descriptive
          * @param proxyPort self-descriptive
          */
-        socksProxy(proxyAddress: String, proxyPort: Number): Connect;
+        socksProxy(proxyAddress: string, proxyPort: number): Connect;
 
         /**
          * Set username and password for proxy.
          * @param username self-descriptive
          * @param password self-descriptive
          */
-        proxyAuth(username: String, password: String): Connect;
+        proxyAuth(username: string, password: string): Connect;
 
         /**
          * Set request method to 'GET'.
@@ -378,19 +368,19 @@ declare module 'sm-utils' {
          * Set cache directory for the connection.
          * @param dir name or path to the directory
          */
-        cacheDir(dir: String): Connect;
+        cacheDir(dir: string): Connect;
 
         /**
          * Set if the body is to be returned as a buffer
          * @param returnAsBuffer self-descriptive
          */
-        asBuffer(returnAsBuffer?: Boolean): Connect;
+        asBuffer(returnAsBuffer?: boolean): Connect;
 
         /**
          * Set the path for file for saving the response.
          * @param filePath self-descriptive
          */
-        save(filePath: String): Connect;
+        save(filePath: string): Connect;
 
         /**
          * It creates and returns a promise based on the information
@@ -440,7 +430,7 @@ declare module 'sm-utils' {
         /**
          * different charsets available
          */
-        const chars: Object;
+        const chars: object;
 
         /**
          * Return a random number between 0 and 1
@@ -457,13 +447,13 @@ declare module 'sm-utils' {
         /**
          * Generate a random string based on the options passed.
          * It can be treated as a Random UUID.
-         *
+         * 
          * You can give length and charset in options.
          * If options is an integer it will treated as length.
          * By default, length is 20 and charset is ALPHA_NUMERIC
          * @param options length of the id or options object
          */
-        function randomString(options: number | randomOpts): String;
+        function randomString(options: number | randomOpts): string;
 
         /**
          * Shuffle an array or a string.
@@ -472,10 +462,10 @@ declare module 'sm-utils' {
          * @param options.randomFunc Use this random function instead of default
          * @param options.seed optionally give a seed to do a constant shuffle
          */
-        function shuffle(itemToShuffle: any[] | String, options: shuffle_options): any[] | String;
+        function shuffle(itemToShuffle: any[] | string, options: shuffle_options): any[] | string;
 
         /**
-         *
+         * 
          * @param seed integer
          */
         function seededRandom(seed: number): randomFunctions;
@@ -484,16 +474,16 @@ declare module 'sm-utils' {
          * Get nanoseconds in base62 or base36 format.
          * @param base36 use base36 format or not
          */
-        function nanoSecondsAlpha(base36?: Boolean): String;
+        function nanoSecondsAlpha(base36?: boolean): string;
 
         /**
          * Generate a sequential id based on current time in millisecond and some randomness.
          * It can be treated as a Sequential UUID. Ideal for use as a DB primary key.
-         *
+         * 
          * NOTE: For best results use atleast 15 characters in base62 and 18 characters in base36 encoding
          * @param options length of the id or object of {length: int, base36: bool}
          */
-        function sequentialID(options: number | Object): String;
+        function sequentialID(options: number | object): string;
 
         /**
          * Get sequential ID in v4 UUID format.
@@ -513,21 +503,21 @@ declare module 'sm-utils' {
          * @param string item to be encoded
          * @param opts object or string specifying the encoding(s)
          */
-        function baseEncode(string: String | Buffer, opts: encodingConversion | String): String | Buffer;
+        function baseEncode(string: string | Buffer, opts: encodingConversion | string): string | Buffer;
 
         /**
          * Decode a string encoded using a given encoding.
          * @param string item to be decoded
          * @param opts object or string specifying the encoding(s)
          */
-        function baseDecode(string: String | Buffer, opts: encodingConversion | String): String;
+        function baseDecode(string: string | Buffer, opts: encodingConversion | string): string;
 
         /**
          * Decode a string encoded using a given encoding to a buffer.
          * @param string item to be decoded
          * @param fromEncoding encoding used to encode the string
          */
-        function baseDecodeToBuffer(string: String | Buffer, fromEncoding: String): Buffer;
+        function baseDecodeToBuffer(string: string | Buffer, fromEncoding: string): Buffer;
 
         /**
          * Compute hash of a string using given algorithm
@@ -536,42 +526,42 @@ declare module 'sm-utils' {
          * @param string string to be hashed
          * @param opts
          */
-        function hash(algo: String, string: String, opts?: encodingOpts): String;
+        function hash(algo: string, string: string, opts?: encodingOpts): string;
 
         /**
          * Compute hash of a string using md5
          * @param string string to be hashed
          * @param options object of {encoding}
          */
-        function md5(string: String, options?: encodingOpts): String;
+        function md5(string: string, options?: encodingOpts): string;
 
         /**
          * Compute hash of a string using sha1
          * @param string string to be hashed
          * @param options object of {encoding}
          */
-        function sha1(string: String, options?: encodingOpts): String;
+        function sha1(string: string, options?: encodingOpts): string;
 
         /**
          * Compute hash of a string using sha256
          * @param string string to be hashed
          * @param options object of {encoding}
          */
-        function sha256(string: String, options?: encodingOpts): String;
+        function sha256(string: string, options?: encodingOpts): string;
 
         /**
          * Compute hash of a string using sha384
          * @param string string to be hashed
          * @param options object of {encoding}
          */
-        function sha384(string: String, options?: encodingOpts): String;
+        function sha384(string: string, options?: encodingOpts): string;
 
         /**
          * Compute hash of a string using sha512
          * @param string string to be hashed
          * @param options object of {encoding}
          */
-        function sha512(string: String, options?: encodingOpts): String;
+        function sha512(string: string, options?: encodingOpts): string;
 
         /**
          * Create cryptographic HMAC digests using given algo
@@ -579,25 +569,25 @@ declare module 'sm-utils' {
          * @param string string to be hashed
          * @param options object of {encoding}
          */
-        function hmac(algo: String, string: String, options?: encodingOpts): String;
+        function hmac(algo: string, string: string, options?: encodingOpts): string;
 
         /**
          * Create cryptographic HMAC digests using sha1
          * @param string string to be hashed
          * @param options object of {encoding}
          */
-        function sha1Hmac(string: String, options?: encodingOpts): String;
+        function sha1Hmac(string: string, options?: encodingOpts): string;
 
         /**
          * Create cryptographic HMAC digests using sha256
          * @param string string to be hashed
          * @param options object of {encoding}
          */
-        function sha256Hmac(string: String, options?: encodingOpts): String;
+        function sha256Hmac(string: string, options?: encodingOpts): string;
 
         /**
          * Sign a message using a private key.
-         *
+         * 
          * NOTE: Generate a key pair using:
          * ```sh
          * openssl ecparam -genkey -name secp256k1 | openssl ec -aes128 -out private.pem
@@ -607,12 +597,12 @@ declare module 'sm-utils' {
          * @param privateKey self-descriptive
          * @param opts opts can have {encoding (default 'hex')
          */
-        function sign(message: String, privateKey: String | Object, opts: encodingOpts): String;
+        function sign(message: string, privateKey: string | object, opts: encodingOpts): string;
 
         /**
          * Verify a message using a public key
          * opts can have {encoding (default 'hex')}
-         *
+         * 
          * NOTE: Generate a key pair using:
          * ```sh
          * openssl ecparam -genkey -name secp256k1 | openssl ec -aes128 -out private.pem
@@ -623,7 +613,7 @@ declare module 'sm-utils' {
          * @param publicKey self-descriptive
          * @param opts opts can have {encoding (default 'hex')}
          */
-        function verify(message: String, signature: String, publicKey: String | Object, opts?: encodingOpts): Boolean;
+        function verify(message: string, signature: string, publicKey: string | object, opts?: encodingOpts): boolean;
 
         /**
          * Encrypt the given string with the given key using AES 256
@@ -633,7 +623,7 @@ declare module 'sm-utils' {
          * @param key key to be used
          * @param options object of {encoding} (default: 'base64url')
          */
-        function encrypt(string: String, key: String, options?: encodingOpts): String;
+        function encrypt(string: string, key: string, options?: encodingOpts): string;
 
         /**
          * Decrypt the given string with the given key encrypted using encrypt
@@ -641,7 +631,7 @@ declare module 'sm-utils' {
          * @param key key to be used
          * @param options object of {encoding} (default: 'base64url')
          */
-        function decrypt(string: String, key: String, options?: encodingOpts): String;
+        function decrypt(string: string, key: string, options?: encodingOpts): string;
 
         /**
          * Encrypt the given string with the given key using AES 256
@@ -652,7 +642,7 @@ declare module 'sm-utils' {
          * @param key key to be used
          * @param options object of {encoding} (default: 'base64url')
          */
-        function encryptStatic(string: String, key: String, options?: encodingOpts): String;
+        function encryptStatic(string: string, key: string, options?: encodingOpts): string;
 
         /**
          * Decrypt the given string with the given key encrypted using encryptStatic
@@ -660,7 +650,7 @@ declare module 'sm-utils' {
          * @param key key to be used
          * @param options object of {encoding} (default: 'base64url')
          */
-        function decryptStatic(string: String, key: String, options?: encodingOpts): String;
+        function decryptStatic(string: string, key: string, options?: encodingOpts): string;
 
         /**
          * Convert a message into an encrypted token by:
@@ -726,13 +716,13 @@ declare module 'sm-utils' {
          * Pack many numbers into a single string
          * @param numbers array of numbers to be packed
          */
-        function packNumbers(numbers: any[]): String;
+        function packNumbers(numbers: any[]): string;
 
         /**
          * Unpack a string packed with packNumbers
          * @param str string to be unpacked
          */
-        function unpackNumbers(str: String): any[];
+        function unpackNumbers(str: string): any[];
 
         /**
          * Generate a random encrypted string that contains a timestamp.
@@ -740,7 +730,7 @@ declare module 'sm-utils' {
          * @param options.length
          * @param options.time epoch time / 1000
          */
-        function encryptedTimestampedId(options: encryptedTimestampedId_options): String;
+        function encryptedTimestampedId(options: encryptedTimestampedId_options): string;
 
         const rot13: typeof Str.rot13;
 
@@ -765,7 +755,7 @@ declare module 'sm-utils' {
         /**
          * if true will use BASE_36 charset
          */
-        base36: Boolean;
+        base36: boolean;
         /**
          * provide a charset string
          */
@@ -984,27 +974,27 @@ declare module 'sm-utils' {
         /**
          * File System utilities wrapped in a class
          */
-        constructor(path: String);
+        constructor(path: string);
 
         /**
          * Checks whether a file exists already.
          */
-        exists(): Boolean;
+        exists(): boolean;
 
         /**
          * Checks whether a file exists already.
          */
-        existsSync(): Boolean;
+        existsSync(): boolean;
 
         /**
          * Returns whether this File object represents a file.
          */
-        isFile(): Boolean;
+        isFile(): boolean;
 
         /**
          * Returns whether this File object represents a directory.
          */
-        isDir(): Boolean;
+        isDir(): boolean;
 
         /**
          * Returns a Date object representing the time when file was last modified.
@@ -1030,61 +1020,61 @@ declare module 'sm-utils' {
          * Returns an object with the stats of the file. If the path for the file
          * is a symlink, then stats of the symlink are returned.
          */
-        lstat(): Object;
+        lstat(): object;
 
         /**
          * Returns an object with the stats of the file. If the path for the file
          * is a symlink, then stats of the target of the symlink are returned.
          */
-        stat(): Object;
+        stat(): object;
 
         /**
          * Returns the size of the file in bytes. If the file is not found
          * or can't be read successfully, 0 is returned.
          */
-        size(): Number;
+        size(): number;
 
         /**
          * Change the mode of the file.
          * @param mode An octal number or a string representing the file mode
          */
-        chmod(mode: Number | String): Number;
+        chmod(mode: number | string): number;
 
         /**
          * Change the mode of the file or directory recursively.
          * @param mode An octal number or a string representing the file mode
          */
-        chmodr(mode: Number | String): Number;
+        chmodr(mode: number | string): number;
 
         /**
          * Change the owner and group of the file.
          * @param user user id, or user name
          * @param group group id, or group name
          */
-        chown(user: Number | String, group: Number | String): Number;
+        chown(user: number | string, group: number | string): number;
 
         /**
          * Change the owner and group of the file recursively.
          * @param user user id, or user name
          * @param group group id, or group name
          */
-        chownr(user: Number | String, group: Number | String): Number;
+        chownr(user: number | string, group: number | string): number;
 
         /**
          * Change the name or location of the file.
          * @param newName new path/location (not just name) for the file
          */
-        rename(newName: String): Number;
+        rename(newName: string): number;
 
         /**
          * Move file to a new location
          * @param newName new location (or path) for the file
          */
-        mv(newName: String): Number;
+        mv(newName: string): number;
 
         /**
          * Unlink the path from the file.
-         *
+         * 
          * NOTE: If the path referred to a
          * symbolic link, the link is removed. If the path is the only link
          * to the file then the file will be deleted.
@@ -1093,7 +1083,7 @@ declare module 'sm-utils' {
 
         /**
          * Remove the file.
-         *
+         * 
          * NOTE: The path is unlinked from the file, but the file
          * is deleted only if the path was the only link to the file and
          * the file was not opened in any other process.
@@ -1102,7 +1092,7 @@ declare module 'sm-utils' {
 
         /**
          * Remove the directory.
-         *
+         * 
          * NOTE: The directory will be deleted only if it is empty.
          */
         rmdir(): void;
@@ -1116,13 +1106,13 @@ declare module 'sm-utils' {
          * Create a directory.
          * @param mode  file mode for the directory
          */
-        mkdir(mode?: Number): void;
+        mkdir(mode?: number): void;
 
         /**
          * Create a new directory and any necessary subdirectories.
          * @param mode  file mode for the directory
          */
-        mkdirp(mode?: Number): void;
+        mkdirp(mode?: number): void;
 
         /**
          * Perform a glob search with the path of the file as the pattern.
@@ -1132,52 +1122,52 @@ declare module 'sm-utils' {
         /**
          * Read contents of the file.
          */
-        read(): String | Buffer;
+        read(): string | Buffer;
 
         /**
          * Create (all necessary directories for) the path of the file/directory.
          * @param mode  file mode for the directory
          */
-        mkdirpPath(mode?: Number): void;
+        mkdirpPath(mode?: number): void;
 
         /**
          * Write contents to the file.
          * @param contents contents to be written to the file
          * @param options  contains options for writing to the file
-         *
+         *        
          *        The options can include parameters such as fileMode, dirMode, retries and encoding.
          */
-        write(contents: String | Buffer, options?: Object): void;
+        write(contents: string | Buffer, options?: object): void;
 
         /**
          * Append contents to the file.
          * @param contents contents to be written to the file
          * @param options  contains options for appending to the file
-         *
+         *        
          *        The options can include parameters such as fileMode, dirMode, retries and encoding.
          */
-        append(contents: String | Buffer, options?: Object): void;
+        append(contents: string | Buffer, options?: object): void;
 
         /**
          * Copy the file to some destination.
          * @param destination path of the destination
          * @param options  options for copying the file
-         *
+         *        
          *        If the overwrite option is explicitly set to false, only then
          *        will the function not attempt to overwrite the file if it (already)
          *        exists at the destination.
          */
-        copy(destination: String, options?: Object): void;
+        copy(destination: string, options?: object): void;
 
         /**
          * Return the canonicalized absolute pathname
          */
-        realpath(): String;
+        realpath(): string;
 
         /**
          * Return the canonicalized absolute pathname
          */
-        realpathSync(): String;
+        realpathSync(): string;
 
     }
 
@@ -1185,19 +1175,19 @@ declare module 'sm-utils' {
      * Returns a new File object representing the file located at 'path'.
      * @param path path of the file
      */
-    function file(path: String): File;
+    function file(path: string): File;
 
     class Lock {
         constructor();
 
         /**
-         *
+         * 
          * @param key
          */
         tryAcquire(key: string): boolean;
 
         /**
-         *
+         * 
          * @param key
          */
         acquire(key: string): boolean | void;
@@ -1217,7 +1207,7 @@ declare module 'sm-utils' {
         /**
          * Job Queue
          */
-        constructor(name: String, redis?: Object, enableWatchdog?: Boolean);
+        constructor(name: string, redis?: object, options?: boolean | queueOpts);
 
         /**
          * Initialise the redis connection
@@ -1225,14 +1215,14 @@ declare module 'sm-utils' {
          * @param enableWatchdog Will watch for stuck jobs due to any connection issues
          * @see https://github.com/Automattic/kue#unstable-redis-connections
          */
-        static init(redis?: Object, enableWatchdog?: Boolean): void;
+        static init(redis?: object, enableWatchdog?: boolean): void;
 
         /**
          * Add a job to the Queue
          * @param input Job data
          * @param opts
          */
-        addJob(input: any, opts: addOpts): Number;
+        addJob(input: any, opts: addOpts): number;
 
         /**
          * Add a job to the Queue, wait for it to process and return result
@@ -1248,47 +1238,47 @@ declare module 'sm-utils' {
          * Set default number of retry attempts for any job added later
          * @param attempts Number of attempts (>= 0), default = 1
          */
-        setAttempts(attempts: Number): void;
+        setAttempts(attempts: number): void;
 
         /**
          * Set delay b/w successive jobs for any job added later
          * @param delay Delay b/w jobs, milliseconds, default = 0
          */
-        setDelay(delay: Number): void;
+        setDelay(delay: number): void;
 
         /**
          * Set default TTL (time to live) for new jobs added from now on,
          * will fail job if not completed in TTL time
          * @param ttl Time in milliseconds, infinite when 0. default = 0
          */
-        setTTL(ttl: Number): void;
+        setTTL(ttl: number): void;
 
         /**
          * Sets default removeOnComplete for any job added to this Queue from now on
          * @param removeOnComplete default = false
          */
-        setRemoveOnCompletion(removeOnComplete: Boolean): void;
+        setRemoveOnCompletion(removeOnComplete: boolean): void;
 
         /**
          * Sets default noFailure for any job added to this Queue from now on.
          * This will mark the job complete even if it fails when true
          * @param noFailure default = false
          */
-        setNoFailure(noFailure: Boolean): void;
+        setNoFailure(noFailure: boolean): void;
 
         /**
          * Attach a processor to the Queue which will keep getting jobs as it completes them
          * @param processor Function to be called to process the job data
          * @param concurrency The number of jobs this processor can handle parallely
          */
-        addProcessor(processor: processorCallback, concurrency?: Number): void;
+        addProcessor(processor: processorCallback, concurrency?: number): void;
 
         /**
          * Pause Queue processing
          * Gives timeout time to all workers to complete their current jobs then stops them
          * @param timeout Time to complete current jobs in ms
          */
-        pauseProcessor(timeout?: Number): void;
+        pauseProcessor(timeout?: number): void;
 
         /**
          * Resume Queue processing
@@ -1300,38 +1290,38 @@ declare module 'sm-utils' {
          * @param queue Queue name
          * @param jobType One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
          */
-        static getCount(queue: String, jobType: String): Number;
+        static getCount(queue: string, jobType: string): number;
 
         /**
          * Return count of inactive jobs in Queue
          */
-        inactiveJobs(): Number;
+        inactiveJobs(): number;
 
         /**
          * Alias for inactiveJobs
          */
-        pendingJobs(): Number;
+        pendingJobs(): number;
 
         /**
          * Return count of completed jobs in Queue
          * Might return 0 if removeOnComplete was true
          */
-        completedJobs(): Number;
+        completedJobs(): number;
 
         /**
          * Return count of failed jobs in Queue
          */
-        failedJobs(): Number;
+        failedJobs(): number;
 
         /**
          * Return count of delayed jobs in Queue
          */
-        delayedJobs(): Number;
+        delayedJobs(): number;
 
         /**
          * Return count of active jobs in Queue
          */
-        activeJobs(): Number;
+        activeJobs(): number;
 
         /**
          * Process a single job in the Queue and mark it complete or failed,
@@ -1345,35 +1335,46 @@ declare module 'sm-utils' {
          * resets active jobs older than specified time
          * @param olderThan Time in milliseconds, default = 5000
          */
-        cleanup(olderThan?: Number): void;
+        cleanup(olderThan?: number): void;
 
         /**
          * Removes any old jobs from queue
          * older than specified time
          * @param olderThan Time in milliseconds, default = 3600000 (1 hr)
          */
-        delete(olderThan?: Number): void;
+        delete(olderThan?: number): void;
 
         /**
          * Function to query the status of a job
          * @param jobId Job id for which status info is required
          */
-        static status(jobId: Number): jobDetails;
+        static status(jobId: number): jobDetails;
 
         /**
          * Manualy process a specific Job. Returns existing result if job already processed
          * @param jobId Id of the job to be processed
          * @param processor Function to be called to process the job data, without ctx
          */
-        static processJobById(jobId: Number, processor: processorCallback): jobDetails;
+        static processJobById(jobId: number, processor: processorCallback): jobDetails;
 
         /**
          * Function shuts down the Queue gracefully.
          * Waits for active jobs to complete until timeout, then marks them failed.
          * @param timeout Time in milliseconds, default = 10000
          */
-        static exit(timeout?: Number): Boolean;
+        static exit(timeout?: number): boolean;
 
+    }
+
+    interface queueOpts {
+        /**
+         * Will watch for stuck jobs default: false
+         */
+        enableWatchdog?: boolean;
+        /**
+         * default logs to console
+         */
+        logger?: Console;
     }
 
     interface addOpts {
@@ -1381,27 +1382,27 @@ declare module 'sm-utils' {
          * Priority of the job, lower number is better
          * Options are : low: 10, normal: 0, medium: -5, high: -10, critical: -15 | Or any integer
          */
-        priority?: Number | String;
+        priority?: number | string;
         /**
          * Number of attempts
          */
-        attempts?: Number;
+        attempts?: number;
         /**
          * Delay in between jobs
          */
-        delay?: Number;
+        delay?: number;
         /**
          * Time to live for job
          */
-        ttl?: Number;
+        ttl?: number;
         /**
          * Remove job on completion
          */
-        removeOnComplete?: Boolean;
+        removeOnComplete?: boolean;
         /**
          * Mark job as complete even if it fails
          */
-        noFailure?: Boolean;
+        noFailure?: boolean;
     }
 
     /**
@@ -1421,18 +1422,18 @@ declare module 'sm-utils' {
         /**
          * Internal options used to set noFailure and extra properties
          */
-        options: Object;
+        options: object;
     }
 
     /**
      * Job status object.
      */
     interface jobDetails {
-        id: Number;
+        id: number;
         /**
          * Name of the Queue
          */
-        type: String;
+        type: string;
         /**
          * Internal data object, includes input and options
          */
@@ -1444,20 +1445,20 @@ declare module 'sm-utils' {
         /**
          * One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
          */
-        state: String;
+        state: string;
         error: any;
         /**
          * unix time stamp
          */
-        created_at: Number;
+        created_at: number;
         /**
          * unix time stamp
          */
-        updated_at: Number;
+        updated_at: number;
         /**
          * Attempts Object
          */
-        attempts: Object;
+        attempts: object;
     }
 
     /**
@@ -1569,10 +1570,6 @@ declare module 'sm-utils' {
 
         /**
          * memoizes a function (caches the return value of the function)
-         * ```js
-         * const cachedFn = cache.memoize('expensiveFn', expensiveFn);
-         * const result = cachedFn('a', 'b');
-         * ```
          * @param key cache key with which to memoize the results
          * @param fn function to memoize
          * @param options ttl in ms/timestring('1d 3h') (default: 0)
@@ -1591,7 +1588,7 @@ declare module 'sm-utils' {
          * Return a global instance of Redis cache
          * @param redis redis redisConf
          */
-        static globalCache(redis: Object): RedisCache;
+        static globalCache(redis: object): RedisCache;
 
         /**
          * gets a value from the cache immediately without waiting
@@ -1764,7 +1761,6 @@ declare module 'sm-utils' {
 
         /**
          * transform a string by replacing characters from from string to to string
-         * eg. `Str.transform('abc', 'bc', 'de') // returns ade`
          * @param str string to transform
          * @param from characters to replace in the string
          * @param to characters to replace with in the string
@@ -1798,19 +1794,19 @@ declare module 'sm-utils' {
          * Rotate a string by 13 characters
          * @param str the string to be rotated
          */
-        function rot13(str: String): String;
+        function rot13(str: string): string;
 
         /**
          * Rotate a string by 47 characters
          * @param str the string to be rotated
          */
-        function rot47(str: String): String;
+        function rot47(str: string): string;
 
         /**
          * Parses a json string, returns null if string is invalid (instead of throwing error)
          * @param str
          */
-        function tryParseJson(str: string): Object | null;
+        function tryParseJson(str: string): object | null;
 
         /**
          * Strip html tags from a string
@@ -1819,7 +1815,7 @@ declare module 'sm-utils' {
          *        allowed: array of allowed tags eg. ['p', 'b', 'span'], default: []
          *        blocked: array of blocked tags eg. ['p'], default: []
          *        replaceWith: replace the removed tags with this string, default: ''
-         *
+         *        
          *        if allowed is not given and blocked is given
          *        then by default all tags not mentioned in blocked are allowed
          */
@@ -1864,7 +1860,7 @@ declare module 'sm-utils' {
          * @param options options object
          *        options: {timeout (in ms), cwd, uid, gid, env (object), shell (eg. /bin/sh), encoding}
          */
-        function exec(command: String, options: Object): Promise<processObject>;
+        function exec(command: string, options: object): Promise<processObject>;
 
         /**
          * Similar to exec but instead executes a given file
@@ -1876,13 +1872,13 @@ declare module 'sm-utils' {
          * execute a command and return its output
          * @param args
          */
-        function execOut(...args: any[]): String;
+        function execOut(...args: any[]): string;
 
         /**
          * execute a file and return its output
          * @param args
          */
-        function execFileOut(...args: any[]): String;
+        function execFileOut(...args: any[]): string;
 
         /**
          * turn off umask for the current process
@@ -1897,40 +1893,40 @@ declare module 'sm-utils' {
         /**
          * get the uid of the user running current process
          */
-        function getuid(): Number;
+        function getuid(): number;
 
         /**
          * get user info from username or uid
          * currently gets user info from /etc/passwd
          * @param user username or uid
          */
-        function getUserInfo(user: String | Number): Object;
+        function getUserInfo(user: string | number): object;
 
         /**
          * get all users in the system
          * currently gets user info from /etc/passwd
          */
-        function getAllUsers(): Object;
+        function getAllUsers(): object;
 
         /**
          * get current time in seconds
          */
-        function time(): Number;
+        function time(): number;
 
         /**
          * get current time in milliseconds (as double)
          */
-        function millitime(): Number;
+        function millitime(): number;
 
         /**
          * get current time in nanoseconds (as double)
          */
-        function nanotime(): Number;
+        function nanotime(): number;
 
         /**
          * get current time in microseconds (as double)
          */
-        function microtime(): Number;
+        function microtime(): number;
 
         /**
          * Sleep for a specified time (in milliseconds)
@@ -1951,7 +1947,7 @@ declare module 'sm-utils' {
          * if a message is given then it will be logged to console before exiting
          * @param code exit code or the message to be logged
          */
-        function exit(code: number | String): void;
+        function exit(code: number | string): void;
 
         /**
          * force exit the process
@@ -1959,7 +1955,7 @@ declare module 'sm-utils' {
          * same as original process.exit (which we override)
          * @param code exit code or the message to be logged
          */
-        function forceExit(code: number | String): void;
+        function forceExit(code: number | string): void;
 
         /**
          * Add an exit handler that runs when process receives an exit signal
@@ -1970,7 +1966,7 @@ declare module 'sm-utils' {
         function onExit(callback: Function, options?: number | timeoutOpts): Promise<void>;
 
         /**
-         *
+         * 
          * @param server
          * @param options
          */
@@ -2120,7 +2116,7 @@ declare module 'sm-utils' {
 
     namespace cfg {
         /**
-         *
+         * 
          * @param key
          * @param defaultValue
          */
@@ -2161,7 +2157,7 @@ declare module 'sm-utils' {
          * read the file specified by the key, and then cache it
          * @param key
          */
-        function read(key: String): any;
+        function read(key: string): any;
 
         function isProduction(): boolean;
 
@@ -2190,7 +2186,6 @@ declare module 'sm-utils' {
     const system: typeof System;
 
     const baseConvert: typeof Crypt.baseConvert;
-
 }
 
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   "author": "Hitesh Khandelwal <hitesh@smartprix.com> (http://www.smartprix.com/)",
   "license": "ISC",
   "dependencies": {
+    "@types/node": "^10.9.3",
+    "@types/request": "^2.47.1",
     "chalk": "^2.4.1",
     "chmodr": "^1.0.2",
     "chownr": "^1.0.1",
@@ -54,8 +56,6 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
     "@otris/jsdoc-tsd": "^1.0.3",
-    "@types/node": "^10.9.3",
-    "@types/request": "^2.47.1",
     "chai": "^4.1.2",
     "docdash": "^1.0.0",
     "eslint": "^5.4.0",

--- a/src/Connect.js
+++ b/src/Connect.js
@@ -28,8 +28,8 @@ const userAgents = {
 /**
  * Returns proxy url based on the proxy options.
  *
- * @param  {Object} proxy proxy options
- * @return {String} proxy url based on the options
+ * @param  {object} proxy proxy options
+ * @return {string} proxy url based on the options
  * @private
  */
 function makeProxyUrl(proxy) {
@@ -86,7 +86,7 @@ class Connect {
 	/**
 	 * Set the url for the connection.
 	 *
-	 * @param {String} url self-descriptive
+	 * @param {string} url self-descriptive
 	 * @return {Connect} self
 	 */
 	url(url) {
@@ -98,7 +98,7 @@ class Connect {
 	 * @static
 	 * Creates and returns a new Connect object with the given url.
 	 *
-	 * @param  {String} url self-descriptive
+	 * @param  {string} url self-descriptive
 	 * @return {Connect}    A new Connect object with url set to the given url
 	 */
 	static url(url) {
@@ -120,7 +120,7 @@ class Connect {
 	/**
 	 * Set or unset the followRedirect option for the connection.
 	 *
-	 * @param  {Boolean} shouldFollowRedirect boolean representing whether to follow redirect or not
+	 * @param  {boolean} shouldFollowRedirect boolean representing whether to follow redirect or not
 	 * @return {Connect}                      self
 	 */
 	followRedirect(shouldFollowRedirect) {
@@ -131,7 +131,7 @@ class Connect {
 	/**
 	 * Set value of a header parameter for the connection.
 	 *
-	 * @param  {String} headerName name of the header parameter whose value is to be set
+	 * @param  {string} headerName name of the header parameter whose value is to be set
 	 * @param  {*} headerValue     value to be set
 	 * @return {Connect}           self
 	 */
@@ -149,7 +149,7 @@ class Connect {
 	/**
 	 * Set value of the headers for the connection.
 	 *
-	 * @param  {Object} headers object representing the headers for the connection
+	 * @param  {object} headers object representing the headers for the connection
 	 * @return {Connect}        self
 	 */
 	headers(headers) {
@@ -161,7 +161,7 @@ class Connect {
 	 * Set the body of the connection object.
 	 *
 	 * @param  {*} body                    value for body
-	 * @param  {String} [contentType=null] string representing the content type of the body
+	 * @param  {string} [contentType=null] string representing the content type of the body
 	 * @return {Connect}                   self
 	 */
 	body(body, contentType = null) {
@@ -184,7 +184,7 @@ class Connect {
 	/**
 	 * Set the 'Referer' field in the headers.
 	 *
-	 * @param  {String} referer referer value
+	 * @param  {string} referer referer value
 	 * @return {Connect}
 	 */
 	referer(referer) {
@@ -195,7 +195,7 @@ class Connect {
 	/**
 	 * Set the 'User-Agent' field in the headers.
 	 *
-	 * @param  {String} userAgent name of the user-agent or its value
+	 * @param  {string} userAgent name of the user-agent or its value
 	 * @return {Connect}          self
 	 */
 	userAgent(userAgent) {
@@ -206,7 +206,7 @@ class Connect {
 	/**
 	 * Set the 'Content-Type' field in the headers.
 	 *
-	 * @param  {String} contentType value for content-type
+	 * @param  {string} contentType value for content-type
 	 * @return {Connect}
 	 */
 	contentType(contentType) {
@@ -217,7 +217,7 @@ class Connect {
 	/**
 	 * Returns whether the content-type is JSON or not
 	 *
-	 * @return {Boolean} true, if content-type is JSON; false, otherwise
+	 * @return {boolean} true, if content-type is JSON; false, otherwise
 	 */
 	isJSON() {
 		return this.options.headers['Content-Type'] === 'application/json';
@@ -230,9 +230,9 @@ class Connect {
 	 * Can also be used to set multiple cookies by passing in an object
 	 * representing the cookies and their values as key:value pairs.
 	 *
-	 * @param  {String|Boolean|Object} cookieName  represents the name of the
+	 * @param  {string|boolean|object} cookieName  represents the name of the
 	 * cookie to be set, or the cookies object
-	 * @param  {Object} cookieValue                cookie value to be set
+	 * @param  {object} cookieValue                cookie value to be set
 	 * @return {Connect}                           self
 	 */
 	cookie(cookieName, cookieValue) {
@@ -253,7 +253,7 @@ class Connect {
 	 * Sets multiple cookies.
 	 * Can be used to enable global cookies, if cookies is set to true.
 	 *
-	 * @param  {Object|Boolean} cookies object representing the cookies
+	 * @param  {object|boolean} cookies object representing the cookies
 	 * and their values as key:value pairs.
 	 * @return {Connect}                self
 	 */
@@ -271,7 +271,7 @@ class Connect {
 	/**
 	 * Enable global cookies.
 	 *
-	 * @param  {Boolean} [enableGlobalCookies=true] self-descriptive
+	 * @param  {boolean} [enableGlobalCookies=true] self-descriptive
 	 * @return {Connect}                            self
 	 */
 	globalCookies(enableGlobalCookies = true) {
@@ -282,7 +282,7 @@ class Connect {
 	/**
 	 * Set the value of cookie jar based on a file (cookie store).
 	 *
-	 * @param  {String} fileName name of (or path to) the file
+	 * @param  {string} fileName name of (or path to) the file
 	 * @return {Connect}         self
 	 */
 	cookieFile(fileName) {
@@ -305,7 +305,7 @@ class Connect {
 	/**
 	 * Set request timeout.
 	 *
-	 * @param  {Number} timeout timeout value in seconds
+	 * @param  {number} timeout timeout value in seconds
 	 * @return {Connect}        self
 	 */
 	timeout(timeout) {
@@ -316,7 +316,7 @@ class Connect {
 	/**
 	 * Set request timeout.
 	 *
-	 * @param  {Number} timeoutInMs timeout value in milliseconds
+	 * @param  {number} timeoutInMs timeout value in milliseconds
 	 * @return {Connect}            self
 	 */
 	timeoutMs(timeoutInMs) {
@@ -338,7 +338,7 @@ class Connect {
 	 * Can also be used to set multiple fields by passing in an object
 	 * representing the field-names and their values as key:value pairs.
 	 *
-	 * @param  {String|Object} fieldName name of the field to be set, or the fields object
+	 * @param  {string|object} fieldName name of the field to be set, or the fields object
 	 * @param  {*} fieldValue            value to be set
 	 * @return {Connect}                 self
 	 */
@@ -356,7 +356,7 @@ class Connect {
 	/**
 	 * Set multiple fields.
 	 *
-	 * @param  {Object} fields object representing the field-names and their
+	 * @param  {object} fields object representing the field-names and their
 	 * values as key:value pairs
 	 * @return {Connect}       self
 	 */
@@ -368,7 +368,7 @@ class Connect {
 	/**
 	 * Set the request method for the connection.
 	 *
-	 * @param  {String} method one of the HTTP request methods ('GET', 'PUT', 'POST', etc.)
+	 * @param  {string} method one of the HTTP request methods ('GET', 'PUT', 'POST', etc.)
 	 * @return {Connect}       self
 	 */
 	method(method) {
@@ -379,8 +379,8 @@ class Connect {
 	/**
 	 * Set username and password for authentication.
 	 *
-	 * @param  {String} username self-descriptive
-	 * @param  {String} password self-descriptive
+	 * @param  {string} username self-descriptive
+	 * @param  {string} password self-descriptive
 	 * @return {Connect}         self
 	 */
 	httpAuth(username, password) {
@@ -402,7 +402,7 @@ class Connect {
 	/**
 	 * Set proxy address (or options).
 	 *
-	 * @param  {String|Object} proxy proxy address, or object representing proxy options
+	 * @param  {string|object} proxy proxy address, or object representing proxy options
 	 * @return {Connect}             self
 	 */
 	proxy(proxy) {
@@ -426,8 +426,8 @@ class Connect {
 	/**
 	 * Set address and port for an http proxy.
 	 *
-	 * @param  {String} proxyAddress self-descriptive
-	 * @param  {Number} proxyPort    self-descriptive
+	 * @param  {string} proxyAddress self-descriptive
+	 * @param  {number} proxyPort    self-descriptive
 	 * @return {Connect}             self
 	 */
 	httpProxy(proxyAddress, proxyPort) {
@@ -443,8 +443,8 @@ class Connect {
 	/**
 	 * Set address and port for a socks proxy.
 	 *
-	 * @param  {String} proxyAddress self-descriptive
-	 * @param  {Number} proxyPort    self-descriptive
+	 * @param  {string} proxyAddress self-descriptive
+	 * @param  {number} proxyPort    self-descriptive
 	 * @return {Connect}             self
 	 */
 	socksProxy(proxyAddress, proxyPort) {
@@ -460,8 +460,8 @@ class Connect {
 	/**
 	 * Set username and password for proxy.
 	 *
-	 * @param  {String} username self-descriptive
-	 * @param  {String} password self-descriptive
+	 * @param  {string} username self-descriptive
+	 * @param  {string} password self-descriptive
 	 * @return {Connect}         self
 	 */
 	proxyAuth(username, password) {
@@ -513,7 +513,7 @@ class Connect {
 	/**
 	 * Set cache directory for the connection.
 	 *
-	 * @param  {String} dir name or path to the directory
+	 * @param  {string} dir name or path to the directory
 	 * @return {Connect}    self
 	 */
 	cacheDir(dir) {
@@ -524,7 +524,7 @@ class Connect {
 	/**
 	 * Set if the body is to be returned as a buffer
 	 *
-	 * @param  {Boolean} [returnAsBuffer=true] self-descriptive
+	 * @param  {boolean} [returnAsBuffer=true] self-descriptive
 	 * @return {Connect}                       self
 	 */
 	asBuffer(returnAsBuffer = true) {
@@ -535,7 +535,7 @@ class Connect {
 	/**
 	 * Set the path for file for saving the response.
 	 *
-	 * @param  {String} filePath self-descriptive
+	 * @param  {string} filePath self-descriptive
 	 * @return {Connect}         self
 	 */
 	save(filePath) {

--- a/src/Crypt/Crypt.js
+++ b/src/Crypt/Crypt.js
@@ -17,7 +17,7 @@ const gzdeflate = promisify(zlib.deflateRaw);
 /**
  * different charsets available
  * @memberof Crypt
- * @type {Object}
+ * @type {object}
  */
 const chars = {};
 
@@ -83,7 +83,7 @@ function countBits(number) {
 /**
  * @typedef {object} randomOpts
  * @property {number} length integer
- * @property {Boolean} base36 if true will use BASE_36 charset
+ * @property {boolean} base36 if true will use BASE_36 charset
  * @property {string} charset provide a charset string
  */
 
@@ -97,7 +97,7 @@ function countBits(number) {
  *
  * @memberof Crypt
  * @param  {number|randomOpts} options length of the id or options object
- * @return {String} id
+ * @return {string} id
  */
 function randomString(options = {}) {
 	let length;
@@ -163,11 +163,11 @@ function randomString(options = {}) {
  * Shuffle an array or a string.
  *
  * @memberof Crypt
- * @param {Array|String} itemToShuffle item which you want to shuffle
- * @param {Object} [options = {}] object of {seed: number}
+ * @param {Array|string} itemToShuffle item which you want to shuffle
+ * @param {object} [options = {}] object of {seed: number}
  * @param {function} options.randomFunc Use this random function instead of default
  * @param {number} options.seed optionally give a seed to do a constant shuffle
- * @return {Array|String} shuffled item
+ * @return {Array|string} shuffled item
  */
 function shuffle(itemToShuffle, options = {}) {
 	let array;
@@ -270,8 +270,8 @@ function seededRandom(seed) {
  * Get nanoseconds in base62 or base36 format.
  *
  * @memberof Crypt
- * @param {Boolean} base36 use base36 format or not
- * @return {String} nanoseconds
+ * @param {boolean} base36 use base36 format or not
+ * @return {string} nanoseconds
  */
 function nanoSecondsAlpha(base36 = false) {
 	const hrtime = process.hrtime();
@@ -295,8 +295,8 @@ function nanoSecondsAlpha(base36 = false) {
  * NOTE: Multiple call within the same millisecond will return 1, 2, 3 so on..
  * The counter will reset on next millisecond
  *
- * @param  {Number} currentTime self-descriptive
- * @return {Number} sequential number
+ * @param  {number} currentTime self-descriptive
+ * @return {number} sequential number
  * @ignore
  */
 function msCounter(currentTime) {
@@ -317,8 +317,8 @@ function msCounter(currentTime) {
  * NOTE: For best results use atleast 15 characters in base62 and 18 characters in base36 encoding
  *
  * @memberof Crypt
- * @param {number|Object} options length of the id or object of {length: int, base36: bool}
- * @return {String} id
+ * @param {number|object} options length of the id or object of {length: int, base36: bool}
+ * @return {string} id
  */
 function sequentialID(options) {
 	let length = 20;
@@ -374,8 +374,8 @@ function sequentialID(options) {
  * where x is any hexadecimal digit and y is one of 8, 9, a, or b
  * eg. f47ac10b-58cc-4372-a567-0e02b2c3d479
  *
- * @param  {String} str the hex string
- * @return {String} the modified string
+ * @param  {string} str the hex string
+ * @return {string} the modified string
  * @private
  */
 function addDashesForUUID(str) {
@@ -420,9 +420,9 @@ function randomUUID() {
  *   'utf8', 'buffer', 'utf16le' ('ucs2')
  *
  * @memberof Crypt
- * @param  {String|Buffer} string item to be encoded
- * @param  {encodingConversion|String} opts   object or string specifying the encoding(s)
- * @return {String|Buffer}        encoded item
+ * @param  {string|Buffer} string item to be encoded
+ * @param  {encodingConversion|string} opts   object or string specifying the encoding(s)
+ * @return {string|Buffer}        encoded item
  *
  * NOTE: If opts is a string, it is considered as the toEncoding.
  * The fromEncoding defaults to binary, while the toEncoding defaults to base64url.
@@ -467,9 +467,9 @@ function baseEncode(string, opts) {
  * Decode a string encoded using a given encoding.
  *
  * @memberof Crypt
- * @param  {String|Buffer} string item to be decoded
- * @param  {encodingConversion|String} opts   object or string specifying the encoding(s)
- * @return {String}        decoded item
+ * @param  {string|Buffer} string item to be decoded
+ * @param  {encodingConversion|string} opts   object or string specifying the encoding(s)
+ * @return {string}        decoded item
  *
  * NOTE: If opts is a string, it is considered as the fromEncoding
  * (i.e that was used to encode the string).
@@ -489,8 +489,8 @@ function baseDecode(string, opts) {
  * Decode a string encoded using a given encoding to a buffer.
  *
  * @memberof Crypt
- * @param  {String|Buffer} string item to be decoded
- * @param  {String} fromEncoding  encoding used to encode the string
+ * @param  {string|Buffer} string item to be decoded
+ * @param  {string} fromEncoding  encoding used to encode the string
  * @return {Buffer}        decoded item
  */
 function baseDecodeToBuffer(string, fromEncoding) {
@@ -514,10 +514,10 @@ function baseDecodeToBuffer(string, fromEncoding) {
  * encoding can be 'hex', 'binary' ('latin1'), 'ascii', 'base64', 'base64url', 'utf8', 'buffer'
  *
  * @memberof Crypt
- * @param {String} algo                      algo to be used for hashing
- * @param {String} string                    string to be hashed
+ * @param {string} algo                      algo to be used for hashing
+ * @param {string} string                    string to be hashed
  * @param {encodingOpts} [opts={}]
- * @return {String}                           encoded hash value
+ * @return {string}                           encoded hash value
  */
 function hash(algo, string, {encoding = 'hex'} = {}) {
 	const hashed = crypto.createHash(algo).update(string);
@@ -534,9 +534,9 @@ function hash(algo, string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using md5
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function md5(string, {encoding = 'hex'} = {}) {
 	return hash('md5', string, {encoding});
@@ -546,9 +546,9 @@ function md5(string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using sha1
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function sha1(string, {encoding = 'hex'} = {}) {
 	return hash('sha1', string, {encoding});
@@ -558,9 +558,9 @@ function sha1(string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using sha256
  *
  * @memberof Crypt
- * @param  {String} string string to be hashed
+ * @param  {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function sha256(string, {encoding = 'hex'} = {}) {
 	return hash('sha256', string, {encoding});
@@ -570,9 +570,9 @@ function sha256(string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using sha384
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function sha384(string, {encoding = 'hex'} = {}) {
 	return hash('sha384', string, {encoding});
@@ -582,9 +582,9 @@ function sha384(string, {encoding = 'hex'} = {}) {
  * Compute hash of a string using sha512
  *
  * @memberof Crypt
- * @param  {String} string string to be hashed
+ * @param  {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded hash value
+ * @return {string} encoded hash value
  */
 function sha512(string, {encoding = 'hex'} = {}) {
 	return hash('sha512', string, {encoding});
@@ -594,10 +594,10 @@ function sha512(string, {encoding = 'hex'} = {}) {
  * Create cryptographic HMAC digests using given algo
  *
  * @memberof Crypt
- * @param {String} algo algo to be used for hashing
- * @param {String} string string to be hashed
+ * @param {string} algo algo to be used for hashing
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded HMAC digest
+ * @return {string} encoded HMAC digest
  */
 function hmac(algo, string, key, {encoding = 'hex'} = {}) {
 	if (typeof key === 'string') key = Buffer.from(key, 'binary');
@@ -615,9 +615,9 @@ function hmac(algo, string, key, {encoding = 'hex'} = {}) {
  * Create cryptographic HMAC digests using sha1
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded HMAC digest
+ * @return {string} encoded HMAC digest
  */
 function sha1Hmac(string, key, {encoding = 'hex'} = {}) {
 	return hmac('sha1', string, key, {encoding});
@@ -627,9 +627,9 @@ function sha1Hmac(string, key, {encoding = 'hex'} = {}) {
  * Create cryptographic HMAC digests using sha256
  *
  * @memberof Crypt
- * @param {String} string string to be hashed
+ * @param {string} string string to be hashed
  * @param {encodingOpts} [options={}] object of {encoding}
- * @return {String} encoded HMAC digest
+ * @return {string} encoded HMAC digest
  */
 function sha256Hmac(string, key, {encoding = 'hex'} = {}) {
 	return hmac('sha256', string, key, {encoding});
@@ -645,10 +645,10 @@ function sha256Hmac(string, key, {encoding = 'hex'} = {}) {
  * ```
  *
  * @memberof Crypt
- * @param  {String} message           the message to be signed
- * @param  {String|Object} privateKey self-descriptive
+ * @param  {string} message           the message to be signed
+ * @param  {string|object} privateKey self-descriptive
  * @param  {encodingOpts} opts        opts can have {encoding (default 'hex')
- * @return {String}                   signature
+ * @return {string}                   signature
  *
  * NOTE: If privateKey is a string, it is treated as a raw key with no passphrase.
  * If privateKey is an object, it must contain the following property:
@@ -677,11 +677,11 @@ function sign(message, privateKey, opts = {}) {
  * ```
  *
  * @memberof Crypt
- * @param  {String} message          message to be verified
- * @param  {String} signature        self-descriptive
- * @param  {String|Object} publicKey self-descriptive
+ * @param  {string} message          message to be verified
+ * @param  {string} signature        self-descriptive
+ * @param  {string|object} publicKey self-descriptive
  * @param  {encodingOpts} [opts={}]  opts can have {encoding (default 'hex')}
- * @return {Boolean}                 true or false, depending on the validity of
+ * @return {boolean}                 true or false, depending on the validity of
  * the signature for the data and public key
  */
 function verify(message, signature, publicKey, opts = {}) {
@@ -707,10 +707,10 @@ function verify(message, signature, publicKey, opts = {}) {
  * Optionally specify encoding in which you want to get the output
  *
  * @memberof Crypt
- * @param  {String} string                          string to be encrypted
- * @param  {String} key                             key to be used
+ * @param  {string} string                          string to be encrypted
+ * @param  {string} key                             key to be used
  * @param {encodingOpts} [options={}] object of {encoding} (default: 'base64url')
- * @return {String}                                 encrypted string
+ * @return {string}                                 encrypted string
  */
 function encrypt(string, key, {encoding = 'base64url'} = {}) {
 	if (string.length < 6) {
@@ -733,10 +733,10 @@ function encrypt(string, key, {encoding = 'base64url'} = {}) {
  * Decrypt the given string with the given key encrypted using encrypt
  *
  * @memberof Crypt
- * @param  {String} string                          string to be decrypted
- * @param  {String} key                             key to be used
+ * @param  {string} string                          string to be decrypted
+ * @param  {string} key                             key to be used
  * @param {encodingOpts} [options={}] object of {encoding} (default: 'base64url')
- * @return {String}                                 decrypted string
+ * @return {string}                                 decrypted string
  */
 function decrypt(string, key, {encoding = 'base64url'} = {}) {
 	if (key.length !== 32) {
@@ -759,10 +759,10 @@ function decrypt(string, key, {encoding = 'base64url'} = {}) {
  * for same string and key.
  *
  * @memberof Crypt
- * @param  {String} string                          string to be encrypted
- * @param  {String} key                             key to be used
+ * @param  {string} string                          string to be encrypted
+ * @param  {string} key                             key to be used
  * @param {encodingOpts} [options={}] object of {encoding} (default: 'base64url')
- * @return {String}                                 encrypted string
+ * @return {string}                                 encrypted string
  */
 function encryptStatic(string, key, {encoding = 'base64url'} = {}) {
 	if (string.length < 6) {
@@ -778,10 +778,10 @@ function encryptStatic(string, key, {encoding = 'base64url'} = {}) {
  * Decrypt the given string with the given key encrypted using encryptStatic
  *
  * @memberof Crypt
- * @param  {String} string                          string to be decrypted
- * @param  {String} key                             key to be used
+ * @param  {string} string                          string to be decrypted
+ * @param  {string} key                             key to be used
  * @param {encodingOpts} [options={}] object of {encoding} (default: 'base64url')
- * @return {String}                                 decrypted string
+ * @return {string}                                 decrypted string
  */
 function decryptStatic(string, key, {encoding = 'base64url'} = {}) {
 	const version = string.substring(0, 1);  // eslint-disable-line
@@ -927,7 +927,7 @@ function base64UrlDecode(string, toEncoding = 'binary') {
  *
  * @memberof Crypt
  * @param  {Array} numbers array of numbers to be packed
- * @return {String}        packed string
+ * @return {string}        packed string
  */
 function packNumbers(numbers) {
 	return baseConvert(
@@ -940,7 +940,7 @@ function packNumbers(numbers) {
  * Unpack a string packed with packNumbers
  *
  * @memberof Crypt
- * @param  {String} str string to be unpacked
+ * @param  {string} str string to be unpacked
  * @return {Array}      array of unpacked numbers
  */
 function unpackNumbers(str) {
@@ -955,10 +955,10 @@ function unpackNumbers(str) {
  * Generate a random encrypted string that contains a timestamp.
  *
  * @memberof Crypt
- * @param {number|Object} options length of the id or object of {length: int}
+ * @param {number|object} options length of the id or object of {length: int}
  * @param {number} options.length
  * @param {number} options.time epoch time / 1000
- * @return {String} id
+ * @return {string} id
  */
 function encryptedTimestampedId(options, key) {
 	const length = options.length || options;
@@ -984,8 +984,8 @@ function encryptedTimestampedId(options, key) {
  * Legacy obfuscation method
  *
  * @memberof Crypt
- * @param  {String} str the string to be obfuscted
- * @return {String} obfuscated string
+ * @param  {string} str the string to be obfuscted
+ * @return {string} obfuscated string
  * @ignore
  */
 async function javaObfuscate(str) {
@@ -1002,8 +1002,8 @@ async function javaObfuscate(str) {
  * Legacy unobfuscation method (obfuscated by javaObfuscate)
  *
  * @memberof Crypt
- * @param  {String} str the obfuscted string
- * @return {String} unobfuscated string
+ * @param  {string} str the obfuscted string
+ * @return {string} unobfuscated string
  * @ignore
  */
 async function javaUnobfuscate(str) {

--- a/src/File.js
+++ b/src/File.js
@@ -43,7 +43,7 @@ class File {
 	/**
 	 * Creates a new File object.
 	 *
-	 * @param  {String} path path to the file
+	 * @param  {string} path path to the file
 	 */
 	constructor(path) {
 		this.path = path;
@@ -52,7 +52,7 @@ class File {
 	/**
 	 * Checks whether a file exists already.
 	 *
-	 * @return {Boolean} true, if the file exists; false, otherwise
+	 * @return {boolean} true, if the file exists; false, otherwise
 	 */
 	async exists() {
 		try {
@@ -67,7 +67,7 @@ class File {
 	/**
 	* Checks whether a file exists already.
 	*
-	* @return {Boolean} true, if the file exists; false, otherwise
+	* @return {boolean} true, if the file exists; false, otherwise
 	 */
 	existsSync() {
 		try {
@@ -82,7 +82,7 @@ class File {
 	/**
 	 * Returns whether this File object represents a file.
 	 *
-	 * @return {Boolean} true, if this object represents a file; false, otherwise
+	 * @return {boolean} true, if this object represents a file; false, otherwise
 	 */
 	async isFile() {
 		try {
@@ -96,7 +96,7 @@ class File {
 	/**
 	 * Returns whether this File object represents a directory.
 	 *
-	 * @return {Boolean} true, if this object represents a directory; false, otherwise
+	 * @return {boolean} true, if this object represents a directory; false, otherwise
 	 */
 	async isDir() {
 		try {
@@ -167,7 +167,7 @@ class File {
 	 * Returns an object with the stats of the file. If the path for the file
 	 * is a symlink, then stats of the symlink are returned.
 	 *
-	 * @return {Object} Stats object
+	 * @return {object} Stats object
 	 */
 	async lstat() {
 		return fs.lstat(this.path);
@@ -177,7 +177,7 @@ class File {
 	 * Returns an object with the stats of the file. If the path for the file
 	 * is a symlink, then stats of the target of the symlink are returned.
 	 *
-	 * @return {Object} Stats object
+	 * @return {object} Stats object
 	 */
 	async stat() {
 		return fs.stat(this.path);
@@ -188,7 +188,7 @@ class File {
 	 * Returns the size of the file in bytes. If the file is not found
 	 * or can't be read successfully, 0 is returned.
 	 *
-	 * @return {Number} Size of file (in bytes)
+	 * @return {number} Size of file (in bytes)
 	 */
 	async size() {
 		try {
@@ -202,8 +202,8 @@ class File {
 	/**
 	 * Change the mode of the file.
 	 *
-	 * @param  {Number|String}  mode An octal number or a string representing the file mode
-	 * @return {Number}              0, on success; -1, if some error occurred
+	 * @param  {number|string}  mode An octal number or a string representing the file mode
+	 * @return {number}              0, on success; -1, if some error occurred
 	 */
 	async chmod(mode) {
 		return fs.chmod(this.path, mode);
@@ -212,8 +212,8 @@ class File {
 	/**
 	 * Change the mode of the file or directory recursively.
 	 *
-	 * @param  {Number|String}  mode An octal number or a string representing the file mode
-	 * @return {Number}              0, on success; -1, if some error occurred
+	 * @param  {number|string}  mode An octal number or a string representing the file mode
+	 * @return {number}              0, on success; -1, if some error occurred
 	 */
 	async chmodr(mode) {
 		return getModule('chmodr')(this.path, mode);
@@ -222,9 +222,9 @@ class File {
 	/**
 	 * Change the owner and group of the file.
 	 *
-	 * @param  {Number|String} user  user id, or user name
-	 * @param  {Number|String} group group id, or group name
-	 * @return {Number}              0, on success; any other number, if some error occurred
+	 * @param  {number|string} user  user id, or user name
+	 * @param  {number|string} group group id, or group name
+	 * @return {number}              0, on success; any other number, if some error occurred
 	 *
 	 * NOTE: If the owner or group is specified as -1, then that ID is not changed
 	 */
@@ -239,9 +239,9 @@ class File {
 	/**
 	 * Change the owner and group of the file recursively.
 	 *
-	 * @param  {Number|String} user  user id, or user name
-	 * @param  {Number|String} group group id, or group name
-	 * @return {Number}              0, on success; any other number, if some error occurred
+	 * @param  {number|string} user  user id, or user name
+	 * @param  {number|string} group group id, or group name
+	 * @return {number}              0, on success; any other number, if some error occurred
 	 *
 	 * NOTE: If the owner or group is specified as -1, then that ID is not changed
 	 */
@@ -256,8 +256,8 @@ class File {
 	/**
 	 * Change the name or location of the file.
 	 *
-	 * @param  {String} newName new path/location (not just name) for the file
-	 * @return {Number}         0, on success; -1, if some error occurred
+	 * @param  {string} newName new path/location (not just name) for the file
+	 * @return {number}         0, on success; -1, if some error occurred
 	 */
 	async rename(newName) {
 		try {
@@ -274,8 +274,8 @@ class File {
 	/**
 	 * Move file to a new location
 	 *
-	 * @param  {String} newName new location (or path) for the file
-	 * @return {Number}         0, on success; -1, if some error occurred
+	 * @param  {string} newName new location (or path) for the file
+	 * @return {number}         0, on success; -1, if some error occurred
 	 */
 	async mv(newName) {
 		return this.rename(newName);
@@ -322,7 +322,7 @@ class File {
 	/**
 	 * Create a directory.
 	 *
-	 * @param  {Number} [mode = 0o755] file mode for the directory
+	 * @param  {number} [mode = 0o755] file mode for the directory
 	 */
 	async mkdir(mode = 0o755) {
 		return fs.mkdir(this.path, mode);
@@ -331,7 +331,7 @@ class File {
 	/**
 	 * Create a new directory and any necessary subdirectories.
 	 *
-	 * @param  {Number} [mode = 0o755] file mode for the directory
+	 * @param  {number} [mode = 0o755] file mode for the directory
 	 */
 	async mkdirp(mode = 0o755) {
 		return getModule('mkdirp')(this.path, mode);
@@ -349,7 +349,7 @@ class File {
 	/**
 	 * Read contents of the file.
 	 *
-	 * @return {String|Buffer} contents of the file
+	 * @return {string|Buffer} contents of the file
 	 */
 	async read() {
 		return fs.readFile(this.path, 'utf8');
@@ -358,7 +358,7 @@ class File {
 	/**
 	 * Create (all necessary directories for) the path of the file/directory.
 	 *
-	 * @param  {Number} [mode = 0o755] file mode for the directory
+	 * @param  {number} [mode = 0o755] file mode for the directory
 	 */
 	async mkdirpPath(mode = 0o755) {
 		return getModule('mkdirp')(_path.dirname(this.path), mode);
@@ -367,8 +367,8 @@ class File {
 	/**
 	 * Write contents to the file.
 	 *
-	 * @param  {String|Buffer} contents contents to be written to the file
-	 * @param  {Object} [options = {}]  contains options for writing to the file
+	 * @param  {string|Buffer} contents contents to be written to the file
+	 * @param  {object} [options = {}]  contains options for writing to the file
 	 *
 	 * The options can include parameters such as fileMode, dirMode, retries and encoding.
 	 */
@@ -396,8 +396,8 @@ class File {
 	/**
 	 * Append contents to the file.
 	 *
-	 * @param  {String|Buffer} contents contents to be written to the file
-	 * @param  {Object} [options = {}]  contains options for appending to the file
+	 * @param  {string|Buffer} contents contents to be written to the file
+	 * @param  {object} [options = {}]  contains options for appending to the file
 	 *
 	 * The options can include parameters such as fileMode, dirMode, retries and encoding.
 	 */
@@ -425,8 +425,8 @@ class File {
 	/**
 	 * Copy the file to some destination.
 	 *
-	 * @param  {String} destination    path of the destination
-	 * @param  {Object} [options = {}] options for copying the file
+	 * @param  {string} destination    path of the destination
+	 * @param  {object} [options = {}] options for copying the file
 	 *
 	 * If the overwrite option is explicitly set to false, only then
 	 * will the function not attempt to overwrite the file if it (already)
@@ -447,7 +447,7 @@ class File {
 	/**
 	 * Return the canonicalized absolute pathname
 	 *
-	 * @return {String} the resolved path
+	 * @return {string} the resolved path
 	 */
 	async realpath() {
 		return fs.realpath(this.path);
@@ -456,7 +456,7 @@ class File {
 	/**
 	 * Return the canonicalized absolute pathname
 	 *
-	 * @return {String} the resolved path
+	 * @return {string} the resolved path
 	 */
 	realpathSync() {
 		return _fs.realpathSync(this.path);
@@ -466,7 +466,7 @@ class File {
 /**
  * Returns a new File object representing the file located at 'path'.
  *
- * @param {String} path path of the file
+ * @param {string} path path of the file
  * @return {File} File object representing the file located at the path
  */
 function file(path) {

--- a/src/Queue.js
+++ b/src/Queue.js
@@ -89,14 +89,18 @@ class Queue {
 	}
 
 	/**
+	 * @typedef {object} queueOpts
+	 * @property {boolean} [enableWatchdog=false] Will watch for stuck jobs default: false
+	 * @property {Console} [logger] default logs to console
+	 */
+
+	/**
 	 * Create a new Queue
 	 * The redis and enableWatchdog settings are required only the first time to init
 	 * Can also be set beforehand by calling Queue.init()
 	 * @param {string} name Name of the queue
 	 * @param {object} [redis={port: 6379, host: '127.0.0.1'}] Redis connection settings object
-	 * @param {boolean|object} [options={}]
-	 * @param {boolean} [options.enableWatchdog=false] Will watch for stuck jobs
-	 * @param {Console} [options.logger]
+	 * @param {boolean|queueOpts} [options={}] enableWatchdog or opts object (default = {})
 	 * Read more here :  https://github.com/Automattic/kue#unstable-redis-connections
 	 */
 	constructor(name, redis = {port: 6379, host: '127.0.0.1'}, options = {}) {

--- a/src/Queue.js
+++ b/src/Queue.js
@@ -70,8 +70,8 @@ class Queue {
 
 	/**
 	 * Initialise the redis connection
-	 * @param {Object} [redis={port: 6379, host: '127.0.0.1'}] Redis connection settings object
-	 * @param {Boolean} [enableWatchdog=false] Will watch for stuck jobs due to any connection issues
+	 * @param {object} [redis={port: 6379, host: '127.0.0.1'}] Redis connection settings object
+	 * @param {boolean} [enableWatchdog=false] Will watch for stuck jobs due to any connection issues
 	 * @see https://github.com/Automattic/kue#unstable-redis-connections
 	 */
 	static init(redis, enableWatchdog) {
@@ -92,10 +92,10 @@ class Queue {
 	 * Create a new Queue
 	 * The redis and enableWatchdog settings are required only the first time to init
 	 * Can also be set beforehand by calling Queue.init()
-	 * @param {String} name Name of the queue
-	 * @param {Object} [redis={port: 6379, host: '127.0.0.1'}] Redis connection settings object
-	 * @param {Boolean|Object} [options={}]
-	 * @param {Boolean} [options.enableWatchdog=false] Will watch for stuck jobs
+	 * @param {string} name Name of the queue
+	 * @param {object} [redis={port: 6379, host: '127.0.0.1'}] Redis connection settings object
+	 * @param {boolean|object} [options={}]
+	 * @param {boolean} [options.enableWatchdog=false] Will watch for stuck jobs
 	 * @param {Console} [options.logger]
 	 * Read more here :  https://github.com/Automattic/kue#unstable-redis-connections
 	 */
@@ -115,21 +115,21 @@ class Queue {
 
 
 	/**
-	 * @typedef {Object} addOpts
-	 * @property {Number|String} [priority=0] Priority of the job, lower number is better
+	 * @typedef {object} addOpts
+	 * @property {number|string} [priority=0] Priority of the job, lower number is better
 	 * Options are : low: 10, normal: 0, medium: -5, high: -10, critical: -15 | Or any integer
-	 * @property {Number} [attempts] Number of attempts
-	 * @property {Number} [delay] Delay in between jobs
-	 * @property {Number} [ttl] Time to live for job
-	 * @property {Boolean} [removeOnComplete] Remove job on completion
-	 * @property {Boolean} [noFailure] Mark job as complete even if it fails
+	 * @property {number} [attempts] Number of attempts
+	 * @property {number} [delay] Delay in between jobs
+	 * @property {number} [ttl] Time to live for job
+	 * @property {boolean} [removeOnComplete] Remove job on completion
+	 * @property {boolean} [noFailure] Mark job as complete even if it fails
 	 */
 
 	/**
 	 * Add a job to the Queue
 	 * @param {*} input Job data
 	 * @param {addOpts} opts
-	 * @return {Number} The ID of the job created
+	 * @return {number} The ID of the job created
 	 */
 	async addJob(input, {
 		priority = 0,
@@ -223,7 +223,7 @@ class Queue {
 
 	/**
 	 * Set default number of retry attempts for any job added later
-	 * @param {Number} attempts Number of attempts (>= 0), default = 1
+	 * @param {number} attempts Number of attempts (>= 0), default = 1
 	 */
 	setAttempts(attempts) {
 		this.attempts = attempts;
@@ -231,7 +231,7 @@ class Queue {
 
 	/**
 	 * Set delay b/w successive jobs for any job added later
-	 * @param {Number} delay Delay b/w jobs, milliseconds, default = 0
+	 * @param {number} delay Delay b/w jobs, milliseconds, default = 0
 	 */
 	setDelay(delay) {
 		this.delay = delay;
@@ -240,7 +240,7 @@ class Queue {
 	/**
 	 * Set default TTL (time to live) for new jobs added from now on,
 	 * will fail job if not completed in TTL time
-	 * @param {Number} ttl Time in milliseconds, infinite when 0. default = 0
+	 * @param {number} ttl Time in milliseconds, infinite when 0. default = 0
 	 */
 	setTTL(ttl) {
 		this.ttl = ttl;
@@ -248,7 +248,7 @@ class Queue {
 
 	/**
 	 * Sets default removeOnComplete for any job added to this Queue from now on
-	 * @param {Boolean} removeOnComplete default = false
+	 * @param {boolean} removeOnComplete default = false
 	 */
 	setRemoveOnCompletion(removeOnComplete) {
 		this.removeOnComplete = removeOnComplete;
@@ -257,7 +257,7 @@ class Queue {
 	/**
 	 * Sets default noFailure for any job added to this Queue from now on.
 	 * This will mark the job complete even if it fails when true
-	 * @param {Boolean} noFailure default = false
+	 * @param {boolean} noFailure default = false
 	 */
 	setNoFailure(noFailure) {
 		this.noFailure = noFailure;
@@ -273,7 +273,7 @@ class Queue {
 	/**
 	 * Attach a processor to the Queue which will keep getting jobs as it completes them
 	 * @param {processorCallback} processor Function to be called to process the job data
-	 * @param {Number} [concurrency=1] The number of jobs this processor can handle parallely
+	 * @param {number} [concurrency=1] The number of jobs this processor can handle parallely
 	 */
 	async addProcessor(processor, concurrency = 1) {
 		if (Queue.queues[this.name].processorAdded) {
@@ -333,7 +333,7 @@ class Queue {
 	/**
 	 * Pause Queue processing
 	 * Gives timeout time to all workers to complete their current jobs then stops them
-	 * @param {Number} [timeout=5000] Time to complete current jobs in ms
+	 * @param {number} [timeout=5000] Time to complete current jobs in ms
 	 */
 	async pauseProcessor(timeout = 5000) {
 		if (!Queue.queues[this.name].processorAdded) throw new Error('No processor present');
@@ -366,9 +366,9 @@ class Queue {
 
 	/**
 	 * Return count of jobs in Queue of JobType
-	 * @param {String} queue Queue name
-	 * @param {String} jobType One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
-	 * @return {Number} count
+	 * @param {string} queue Queue name
+	 * @param {string} jobType One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
+	 * @return {number} count
 	 */
 	static async getCount(queue, jobType) {
 		return new Promise((resolve, reject) => {
@@ -380,7 +380,7 @@ class Queue {
 	}
 	/**
 	 * Return count of inactive jobs in Queue
-	 * @return {Number} inactiveCount
+	 * @return {number} inactiveCount
 	 */
 	async inactiveJobs() {
 		return Queue.getCount(this.name, 'inactive');
@@ -388,7 +388,7 @@ class Queue {
 
 	/**
 	 * Alias for inactiveJobs
- 	 * @return {Number} inactiveCount
+ 	 * @return {number} inactiveCount
 	 */
 	pendingJobs() {
 		return this.inactiveJobs();
@@ -397,7 +397,7 @@ class Queue {
 	/**
 	 * Return count of completed jobs in Queue
 	 * Might return 0 if removeOnComplete was true
-	 * @return {Number} completeCount
+	 * @return {number} completeCount
 	 */
 	async completedJobs() {
 		return Queue.getCount(this.name, 'complete');
@@ -405,7 +405,7 @@ class Queue {
 
 	/**
 	 * Return count of failed jobs in Queue
-	 * @return {Number} failedCount
+	 * @return {number} failedCount
 	 */
 	async failedJobs() {
 		return Queue.getCount(this.name, 'failed');
@@ -413,7 +413,7 @@ class Queue {
 
 	/**
 	 * Return count of delayed jobs in Queue
-	 * @return {Number} delayedCount
+	 * @return {number} delayedCount
 	 */
 	async delayedJobs() {
 		return Queue.getCount(this.name, 'delayed');
@@ -421,7 +421,7 @@ class Queue {
 
 	/**
 	 * Return count of active jobs in Queue
-	 * @return {Number} activeCount
+	 * @return {number} activeCount
 	 */
 	async activeJobs() {
 		return Queue.getCount(this.name, 'active');
@@ -429,23 +429,23 @@ class Queue {
 
 	/**
 	 * Internal data object
-	 * @typedef {Object} internalData
+	 * @typedef {object} internalData
 	 * @property {*} input Input data given to job
-	 * @property {Object} options Internal options used to set noFailure and extra properties
+	 * @property {object} options Internal options used to set noFailure and extra properties
 	 */
 
 	/**
 	 * Job status object.
-	 * @typedef {Object} jobDetails
-	 * @property {Number} id
-	 * @property {String} type Name of the Queue
+	 * @typedef {object} jobDetails
+	 * @property {number} id
+	 * @property {string} type Name of the Queue
 	 * @property {internalData} data Internal data object, includes input and options
 	 * @property {*} result Result of the processor callback
-	 * @property {String} state One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
+	 * @property {string} state One of {'inactive', 'delayed' ,'active', 'complete', 'failed'}
 	 * @property {*} error
-	 * @property {Number} created_at unix time stamp
-	 * @property {Number} updated_at unix time stamp
-	 * @property {Object} attempts Attempts Object
+	 * @property {number} created_at unix time stamp
+	 * @property {number} updated_at unix time stamp
+	 * @property {object} attempts Attempts Object
 	 */
 
 	/**
@@ -469,7 +469,7 @@ class Queue {
 	/**
 	 * Cleanup function to be called during startup,
 	 * resets active jobs older than specified time
-	 * @param {Number} [olderThan=5000] Time in milliseconds, default = 5000
+	 * @param {number} [olderThan=5000] Time in milliseconds, default = 5000
 	 */
 	async cleanup(olderThan = 5000) {
 		const n = await Queue.getCount(this.name, 'active');
@@ -479,7 +479,7 @@ class Queue {
 	/**
 	 * Removes any old jobs from queue
 	 * older than specified time
-	 * @param {Number} [olderThan=3600000] Time in milliseconds, default = 3600000 (1 hr)
+	 * @param {number} [olderThan=3600000] Time in milliseconds, default = 3600000 (1 hr)
 	 */
 	async delete(olderThan = 3600000) {
 		const completed = await this.completedJobs();
@@ -502,7 +502,7 @@ class Queue {
 
 	/**
 	 * Function to query the status of a job
-	 * @param {Number} jobId Job id for which status info is required
+	 * @param {number} jobId Job id for which status info is required
 	 * @return {jobDetails} Object full of job details like state, time, attempts, etc.
 	 */
 	static async status(jobId) {
@@ -520,7 +520,7 @@ class Queue {
 
 	/**
 	 * Manualy process a specific Job. Returns existing result if job already processed
-	 * @param {Number} jobId Id of the job to be processed
+	 * @param {number} jobId Id of the job to be processed
 	 * @param {processorCallback} processor Function to be called to process the job data, without ctx
 	 * @return {jobDetails} Result of processor function and job object of completed job
 	 */
@@ -539,8 +539,8 @@ class Queue {
 	/**
 	 * Function shuts down the Queue gracefully.
 	 * Waits for active jobs to complete until timeout, then marks them failed.
-	 * @param {Number} [timeout=10000] Time in milliseconds, default = 10000
-	 * @return {Boolean}
+	 * @param {number} [timeout=10000] Time in milliseconds, default = 10000
+	 * @return {boolean}
 	 */
 	static async exit(timeout = 10000) {
 		return new Promise((resolve) => {

--- a/src/RedisCache.js
+++ b/src/RedisCache.js
@@ -698,7 +698,7 @@ class RedisCache {
 
 	/**
 	 * Return a global instance of Redis cache
-	 * @param {Object} redis redis redisConf
+	 * @param {object} redis redis redisConf
 	 * @return {RedisCache}
 	 */
 	static globalCache(redis) {

--- a/src/Str/Str.js
+++ b/src/Str/Str.js
@@ -212,8 +212,8 @@ function spaceClean(str) {
  * Rotate a string by 13 characters
  *
  * @memberof Str
- * @param {String} str the string to be rotated
- * @return {String} rotated string
+ * @param {string} str the string to be rotated
+ * @return {string} rotated string
  */
 function rot13(str) {
 	const s = [];
@@ -237,8 +237,8 @@ function rot13(str) {
  * Rotate a string by 47 characters
  *
  * @memberof Str
- * @param {String} str the string to be rotated
- * @return {String} rotated string
+ * @param {string} str the string to be rotated
+ * @return {string} rotated string
  */
 function rot47(str) {
 	const s = [];
@@ -260,7 +260,7 @@ function rot47(str) {
  *
  * @memberof Str
  * @param {string} str
- * @return {Object|null}
+ * @return {object|null}
  */
 function tryParseJson(str) {
 	try {

--- a/src/System/System.js
+++ b/src/System/System.js
@@ -70,8 +70,8 @@ function execWrapper(method, args) {
 /**
  * Execute the given command in a shell.
  * @memberof System
- * @param {String} command
- * @param {Object} options options object
+ * @param {string} command
+ * @param {object} options options object
  * options: {timeout (in ms), cwd, uid, gid, env (object), shell (eg. /bin/sh), encoding}
  * @return {Promise<processObject>}
  */
@@ -94,7 +94,7 @@ function execFile(...args) {
  *
  * @memberof System
  * @param {Array<any>} args
- * @return {String} output of the command's execution
+ * @return {string} output of the command's execution
  */
 async function execOut(...args) {
 	return (await exec.apply(this, args)).stdout.toString();
@@ -105,7 +105,7 @@ async function execOut(...args) {
  *
  * @memberof System
  * @param {Array<any>} args
- * @return {String} output of the file's execution
+ * @return {string} output of the file's execution
  */
 async function execFileOut(...args) {
 	return (await execFile.apply(this, args)).stdout.toString();
@@ -139,7 +139,7 @@ function yesUmask() {
  * get the uid of the user running current process
  *
  * @memberof System
- * @return {Number}  uid
+ * @return {number}  uid
  */
 function getuid() {
 	return process.getuid();
@@ -150,8 +150,8 @@ function getuid() {
  * currently gets user info from /etc/passwd
  *
  * @memberof System
- * @param  {String|Number} user username or uid
- * @return {Object}             the user's information
+ * @param  {string|number} user username or uid
+ * @return {object}             the user's information
  */
 function getUserInfo(user) {
 	user = (user === undefined) ? process.getuid() : user;
@@ -177,7 +177,7 @@ function getUserInfo(user) {
  * currently gets user info from /etc/passwd
  *
  * @memberof System
- * @return {Object}  object containing info for all users, as username:info pairs
+ * @return {object}  object containing info for all users, as username:info pairs
  */
 function getAllUsers() {
 	return new Promise((resolve, reject) => {
@@ -201,7 +201,7 @@ function getAllUsers() {
  * get current time in seconds
  *
  * @memberof System
- * @return {Number}  current time in seconds
+ * @return {number}  current time in seconds
  */
 function time() {
 	return Math.floor(Date.now() / 1000);
@@ -211,7 +211,7 @@ function time() {
  * get current time in milliseconds (as double)
  *
  * @memberof System
- * @return {Number}  current time in milliseconds
+ * @return {number}  current time in milliseconds
  */
 function millitime() {
 	return (Date.now() / 1000);
@@ -221,7 +221,7 @@ function millitime() {
  * get current time in nanoseconds (as double)
  *
  * @memberof System
- * @return {Number}  current time in nanoseconds
+ * @return {number}  current time in nanoseconds
  */
 function nanotime() {
 	const hrtime = process.hrtime();
@@ -234,7 +234,7 @@ function nanotime() {
  * get current time in microseconds (as double)
  *
  * @memberof System
- * @return {Number}  current time in microseconds
+ * @return {number}  current time in microseconds
  */
 function microtime() {
 	return nanotime();
@@ -271,7 +271,7 @@ function tick() {
  * if a message is given then it will be logged to console before exiting
  *
  * @memberof System
- * @param {number|String} code exit code or the message to be logged
+ * @param {number|string} code exit code or the message to be logged
  * @return {void}
  */
 function exit(code) {
@@ -291,7 +291,7 @@ function exit(code) {
  * same as original process.exit (which we override)
  *
  * @memberof System
- * @param {number|String} code exit code or the message to be logged
+ * @param {number|string} code exit code or the message to be logged
  * @return {void}
  */
 function forceExit(code) {

--- a/src/cfg.js
+++ b/src/cfg.js
@@ -35,7 +35,7 @@ function merge(conf, confPrivate) {
 
 /**
  * Reads a config value
- * @param {String} key key to read, can be nested like `a.b.c`
+ * @param {string} key key to read, can be nested like `a.b.c`
  * @param {*} defaultValue value to return if key is not found
  * @return {any}
  */
@@ -190,7 +190,7 @@ cfg.file = function (file, options = {}) {
 /**
  * read the file specified by the key, and then cache it
  * @memberOf config
- * @param {String} key
+ * @param {string} key
  * @return {any} value
  */
 cfg.read = function (key) {

--- a/src/cfg.js
+++ b/src/cfg.js
@@ -76,7 +76,7 @@ function readDefaultConfigFiles() {
 	readEnvVariables();
 }
 /**
- * @memberOf config
+ * @memberof config
  * @param {string} key
  * @param {any} defaultValue
  * @return {any}
@@ -87,7 +87,7 @@ cfg.get = function (key, defaultValue) {
 
 /** set values in global config
  * you can also give key as an object to assign all key values from it
- * @memberOf config
+ * @memberof config
  * @return {null}
  */
 cfg.set = function (key, value) {
@@ -110,7 +110,7 @@ cfg.set = function (key, value) {
  * set values in global config with an object to assign all key values from it
  * if a key already exists then it is merged with new value
  * if obj is not an Object then nothing happens
- * @memberOf config
+ * @memberof config
  * @return {null}
  */
 cfg.merge = function (obj) {
@@ -130,7 +130,7 @@ cfg.merge = function (obj) {
  * set values in global config with an object to assign all key values from it
  * if a key already exists then it is assigned with new value
  * if obj is not an Object then nothing happens
- * @memberOf config
+ * @memberof config
  * @return {null}
  */
 cfg.assign = function (obj) {
@@ -146,7 +146,7 @@ cfg.assign = function (obj) {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {void}
  */
 cfg.delete = function (key) {
@@ -156,7 +156,7 @@ cfg.delete = function (key) {
 
 /**
  * read config from a file, and merge with existing config
- * @memberOf config
+ * @memberof config
  * @param {string} file path of the file to read (only absolute paths)
  * @param {object} options
  * 	options = {ignoreErrors = ignore all errors, ignoreNotFound = ignore if file not found}
@@ -189,7 +189,7 @@ cfg.file = function (file, options = {}) {
 
 /**
  * read the file specified by the key, and then cache it
- * @memberOf config
+ * @memberof config
  * @param {string} key
  * @return {any} value
  */
@@ -215,7 +215,7 @@ cfg.read = function (key) {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isProduction = function () {
@@ -223,7 +223,7 @@ cfg.isProduction = function () {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isStaging = function () {
@@ -232,7 +232,7 @@ cfg.isStaging = function () {
 
 /**
  * Returns true if env is production or staging
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isProductionLike = function () {
@@ -240,7 +240,7 @@ cfg.isProductionLike = function () {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isTest = function () {
@@ -248,7 +248,7 @@ cfg.isTest = function () {
 };
 
 /**
- * @memberOf config
+ * @memberof config
  * @return {boolean}
  */
 cfg.isDev = function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,13 +18,7 @@
   optionalDependencies:
     chokidar "^2.0.3"
 
-"@babel/code-frame@7.0.0-beta.54", "@babel/code-frame@^7.0.0-beta.40":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.54.tgz#0024f96fdf7028a21d68e273afd4e953214a1ead"
-  dependencies:
-    "@babel/highlight" "7.0.0-beta.54"
-
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.40":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
   dependencies:
@@ -48,16 +42,6 @@
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
-
-"@babel/generator@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.54.tgz#c043c7eebeebfd7e665d95c281a4aafc83d4e1c9"
-  dependencies:
-    "@babel/types" "7.0.0-beta.54"
-    jsesc "^2.5.1"
-    lodash "^4.17.5"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
 
 "@babel/generator@^7.0.0":
   version "7.0.0"
@@ -105,14 +89,6 @@
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-function-name@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.54.tgz#307875507a1eda2482a09a9a4df6a25632ffb34b"
-  dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.54"
-    "@babel/template" "7.0.0-beta.54"
-    "@babel/types" "7.0.0-beta.54"
-
 "@babel/helper-function-name@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz#a68cc8d04420ccc663dd258f9cc41b8261efa2d4"
@@ -120,12 +96,6 @@
     "@babel/helper-get-function-arity" "^7.0.0"
     "@babel/template" "^7.0.0"
     "@babel/types" "^7.0.0"
-
-"@babel/helper-get-function-arity@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.54.tgz#757bd189b077074a004028cfde5f083c306cc6c4"
-  dependencies:
-    "@babel/types" "7.0.0-beta.54"
 
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
@@ -204,12 +174,6 @@
     "@babel/template" "^7.0.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-split-export-declaration@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.54.tgz#89cd8833c95481a0827ac6a1bfccddb92b75a109"
-  dependencies:
-    "@babel/types" "7.0.0-beta.54"
-
 "@babel/helper-split-export-declaration@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
@@ -233,14 +197,6 @@
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
 
-"@babel/highlight@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.54.tgz#155d507358329b8e7068970017c3fd74a9b08584"
-  dependencies:
-    chalk "^2.0.0"
-    esutils "^2.0.2"
-    js-tokens "^3.0.0"
-
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
@@ -248,10 +204,6 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
-
-"@babel/parser@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.54.tgz#c01aa63b57c9c8dce8744796c81d9df121f20db4"
 
 "@babel/parser@^7.0.0":
   version "7.0.0"
@@ -581,15 +533,6 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
-"@babel/template@7.0.0-beta.54":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.54.tgz#d5b0d2d2d55c0e78b048c61a058f36cfd7d91af3"
-  dependencies:
-    "@babel/code-frame" "7.0.0-beta.54"
-    "@babel/parser" "7.0.0-beta.54"
-    "@babel/types" "7.0.0-beta.54"
-    lodash "^4.17.5"
-
 "@babel/template@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0.tgz#c2bc9870405959c89a9c814376a2ecb247838c80"
@@ -598,7 +541,7 @@
     "@babel/parser" "^7.0.0"
     "@babel/types" "^7.0.0"
 
-"@babel/traverse@^7.0.0":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.0.0-beta.40":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0.tgz#b1fe9b6567fdf3ab542cfad6f3b31f854d799a61"
   dependencies:
@@ -612,29 +555,7 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
-"@babel/traverse@^7.0.0-beta.40":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.54.tgz#2c17f98dcdbf19aa918fde128f0e1a0bc089e05a"
-  dependencies:
-    "@babel/code-frame" "7.0.0-beta.54"
-    "@babel/generator" "7.0.0-beta.54"
-    "@babel/helper-function-name" "7.0.0-beta.54"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.54"
-    "@babel/parser" "7.0.0-beta.54"
-    "@babel/types" "7.0.0-beta.54"
-    debug "^3.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.5"
-
-"@babel/types@7.0.0-beta.54", "@babel/types@^7.0.0-beta.40":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.54.tgz#025ad68492fed542c13f14c579a44c848e531063"
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.17.5"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.0.0":
+"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.40":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
   dependencies:
@@ -643,13 +564,14 @@
     to-fast-properties "^2.0.0"
 
 "@otris/jsdoc-tsd@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@otris/jsdoc-tsd/-/jsdoc-tsd-1.0.3.tgz#24001789b4fdad2118b1ff0baffbafb0395b6115"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@otris/jsdoc-tsd/-/jsdoc-tsd-1.0.4.tgz#c12ba91f2c73059e7fede7db838538511d4d1bde"
   dependencies:
     comment-parser "^0.5.0"
-    dts-dom "^0.1.22"
+    copyfiles "^2.0.0"
+    dts-dom "^3.1.0"
     node-version-compare "^1.0.1"
-    shelljs "^0.7.8"
+    shelljs "^0.8.2"
 
 "@types/babel-types@*", "@types/babel-types@^7.0.0":
   version "7.0.4"
@@ -672,8 +594,8 @@
     "@types/node" "*"
 
 "@types/node@*", "@types/node@^10.9.3":
-  version "10.9.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.3.tgz#85f288502503ade0b3bfc049fe1777b05d0327d5"
+  version "10.9.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
 
 "@types/request@^2.47.1":
   version "2.47.1"
@@ -730,8 +652,8 @@ acorn@^4.0.4, acorn@~4.0.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.3, acorn@^5.5.0, acorn@^5.6.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.2.tgz#91fa871883485d06708800318404e72bfb26dcc5"
 
 ajv-keywords@^3.0.0:
   version "3.2.0"
@@ -746,14 +668,14 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.0.1, ajv@^6.5.0:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
+ajv@^6.0.1, ajv@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.3.tgz#71a569d189ecf4f4f321224fecb166f071dd90f9"
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
-    uri-js "^4.2.1"
+    uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -862,8 +784,10 @@ asap@~2.0.3:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 asn1@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  dependencies:
+    safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -890,8 +814,8 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
 atob@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -1061,8 +985,8 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
 bluebird@~3.5.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
 
 body-parser@1.18.2:
   version "1.18.2"
@@ -1129,8 +1053,8 @@ browserslist@^4.1.0:
     node-releases "^1.0.0-alpha.11"
 
 buffer-from@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -1172,9 +1096,13 @@ camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
 caniuse-lite@^1.0.30000878:
-  version "1.0.30000883"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000883.tgz#597c1eabfb379bd9fbeaa778632762eb574706ac"
+  version "1.0.30000884"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000884.tgz#eb82a959698745033b26a4dcd34d89dba7cc6eb3"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1206,7 +1134,7 @@ chai@^4.1.2:
 
 chalk@^1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
     ansi-styles "^2.2.1"
     escape-string-regexp "^1.0.2"
@@ -1224,7 +1152,7 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1:
 
 chalk@~0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  resolved "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
   dependencies:
     ansi-styles "~1.0.0"
     has-color "~0.1.0"
@@ -1236,9 +1164,9 @@ character-parser@^2.1.1:
   dependencies:
     is-regex "^1.0.3"
 
-chardet@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
 check-error@^1.0.1:
   version "1.0.2"
@@ -1285,10 +1213,10 @@ class-utils@^0.3.5:
     static-extend "^0.1.1"
 
 clean-css@^4.1.11:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"
   dependencies:
-    source-map "0.5.x"
+    source-map "~0.6.0"
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -1316,6 +1244,14 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 cluster-key-slot@^1.0.6:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz#d5deff2a520717bc98313979b687309b2d368e29"
@@ -1336,14 +1272,14 @@ collection-visit@^1.0.0:
     object-visit "^1.0.0"
 
 color-convert@^1.9.0:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   dependencies:
-    color-name "1.1.1"
+    color-name "1.1.3"
 
-color-name@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 colors@~0.6.0-1:
   version "0.6.2"
@@ -1366,8 +1302,8 @@ commander@2.9.0:
     graceful-readlink ">= 1.0.0"
 
 commander@^2.8.1:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 commander@~2.1.0:
   version "2.1.0"
@@ -1432,6 +1368,17 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+copyfiles@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.0.0.tgz#bbd78bb78e8fd6db5c67adf54249317b24560f2a"
+  dependencies:
+    glob "^7.0.5"
+    minimatch "^3.0.3"
+    mkdirp "^0.5.1"
+    noms "0.0.0"
+    through2 "^2.0.1"
+    yargs "^11.0.0"
+
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
@@ -1439,6 +1386,14 @@ core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^6.0.5:
   version "6.0.5"
@@ -1616,15 +1571,16 @@ double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
 
-dts-dom@^0.1.22:
-  version "0.1.25"
-  resolved "https://registry.yarnpkg.com/dts-dom/-/dts-dom-0.1.25.tgz#799a24abfcd588d8e449b5609ece193195ef5df4"
+dts-dom@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/dts-dom/-/dts-dom-3.1.0.tgz#7f53cf58305180bfd9475d294ea028136162626c"
 
 ecc-jsbn@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
   dependencies:
     jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -1735,8 +1691,8 @@ eslint-plugin-import@2.9.0:
     read-pkg-up "^2.0.0"
 
 eslint-plugin-vue@^4.2.2:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-4.7.0.tgz#dd1e9440adaee53915fd5b2c590ebb6bc265d646"
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-4.7.1.tgz#c829b9fc62582c1897b5a0b94afd44ecca511e63"
   dependencies:
     vue-eslint-parser "^2.0.3"
 
@@ -1767,11 +1723,11 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
 eslint@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.4.0.tgz#d068ec03006bb9e06b429dc85f7e46c1b69fac62"
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.5.0.tgz#8557fcceab5141a8197da9ffd9904f89f64425c6"
   dependencies:
-    ajv "^6.5.0"
-    babel-code-frame "^6.26.0"
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.5.3"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^3.1.0"
@@ -1786,11 +1742,11 @@ eslint@^5.4.0:
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
     globals "^11.7.0"
-    ignore "^4.0.2"
+    ignore "^4.0.6"
     imurmurhash "^0.1.4"
-    inquirer "^5.2.0"
+    inquirer "^6.1.0"
     is-resolvable "^1.1.0"
-    js-yaml "^3.11.0"
+    js-yaml "^3.12.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.5"
@@ -1803,7 +1759,7 @@ eslint@^5.4.0:
     progress "^2.0.0"
     regexpp "^2.0.0"
     require-uncached "^1.0.3"
-    semver "^5.5.0"
+    semver "^5.5.1"
     strip-ansi "^4.0.0"
     strip-json-comments "^2.0.1"
     table "^4.0.3"
@@ -1868,6 +1824,18 @@ etc-passwd@^0.1.1:
   resolved "https://registry.yarnpkg.com/etc-passwd/-/etc-passwd-0.1.1.tgz#a1c8990df26e1a4305f822ff618d8a144d88d169"
   dependencies:
     lazylines "= 1.0.0"
+
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -1937,12 +1905,12 @@ extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
-external-editor@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+external-editor@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
   dependencies:
-    chardet "^0.4.0"
-    iconv-lite "^0.4.17"
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
 extglob@^2.0.4:
@@ -2144,6 +2112,10 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -2193,7 +2165,7 @@ glob@7.0.x:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob@7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2204,7 +2176,7 @@ glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
@@ -2382,9 +2354,15 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.4:
+iconv-lite@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
@@ -2394,9 +2372,9 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.2.tgz#0a8dd228947ec78c2d7f736b1642a9f7317c1905"
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -2409,7 +2387,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2417,20 +2395,20 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-inquirer@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
+inquirer@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.0"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    external-editor "^2.1.0"
+    external-editor "^3.0.0"
     figures "^2.0.0"
-    lodash "^4.3.0"
+    lodash "^4.17.10"
     mute-stream "0.0.7"
     run-async "^2.2.0"
-    rxjs "^5.5.2"
+    rxjs "^6.1.0"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -2487,9 +2465,9 @@ ip-address@~5.8.0:
     lodash.repeat "^4.1.0"
     sprintf-js "1.1.0"
 
-ipaddr.js@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b"
+ipaddr.js@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -2646,6 +2624,10 @@ is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -2657,6 +2639,10 @@ is-utf8@^0.2.0:
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -2721,15 +2707,15 @@ js-stringify@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/js-stringify/-/js-stringify-1.0.2.tgz#1736fddfd9724f28a3682adc6230ae7e4e9679db"
 
-js-tokens@^3.0.0, js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@3.x, js-yaml@^3.11.0:
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+js-yaml@3.x, js-yaml@^3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -2998,7 +2984,7 @@ lodash.values@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -3016,7 +3002,7 @@ lru-cache@^2.5.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
-lru-cache@^4.1.3:
+lru-cache@^4.0.1, lru-cache@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
@@ -3051,6 +3037,12 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -3077,21 +3069,11 @@ micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-mime-db@~1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
-
 mime-db@~1.36.0:
   version "1.36.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
 
-mime-types@^2.1.12, mime-types@~2.1.18:
-  version "2.1.18"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
-  dependencies:
-    mime-db "~1.33.0"
-
-mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.20"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
   dependencies:
@@ -3119,19 +3101,19 @@ minimatch@2.x:
 
 minimist@0.0.8:
   version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 minimist@~0.0.1:
   version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 minipass@^2.2.1, minipass@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.3.tgz#a7dcc8b7b833f5d368759cce544dccb55f50f233"
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.4.tgz#4768d7605ed6194d6d576169b9e12ef71e9d9957"
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
@@ -3151,7 +3133,7 @@ mixin-deep@^1.2.0:
 
 mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
@@ -3180,8 +3162,8 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.9.2:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -3212,8 +3194,8 @@ natural@^0.2.0:
     underscore ">=1.3.1"
 
 needle@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.2.tgz#1120ca4c41f2fcc6976fd28a8968afe239929418"
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -3230,8 +3212,8 @@ nib@~1.1.2:
     stylus "0.54.5"
 
 nice-try@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -3283,6 +3265,13 @@ nomnomnomnom@^2.0.0:
     chalk "~0.4.0"
     underscore "~1.6.0"
 
+noms@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "~1.0.31"
+
 nopt@3.x:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -3312,15 +3301,21 @@ normalize-path@^2.1.1:
     remove-trailing-separator "^1.0.1"
 
 npm-bundled@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
 
 npm-packlist@^1.1.6:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.10.tgz#1039db9e985727e464df066f4cf0ab6ef85c398a"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -3414,9 +3409,17 @@ os-homedir@^1.0.0:
 
 os-locale@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  resolved "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
   dependencies:
     lcid "^1.0.0"
+
+os-locale@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  dependencies:
+    execa "^0.7.0"
+    lcid "^1.0.0"
+    mem "^1.1.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -3436,6 +3439,10 @@ output-file-sync@^2.0.0:
     graceful-fs "^4.1.11"
     is-plain-obj "^1.1.0"
     mkdirp "^0.5.1"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -3489,13 +3496,13 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.1:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -3590,19 +3597,19 @@ promise@^7.0.1:
     asap "~2.0.3"
 
 proxy-addr@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
   dependencies:
     forwarded "~0.1.2"
-    ipaddr.js "1.6.0"
+    ipaddr.js "1.8.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 psl@^1.1.24:
-  version "1.1.28"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
 
 pug-attrs@^2.0.3:
   version "2.0.3"
@@ -3774,7 +3781,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6:
+readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -3785,6 +3792,15 @@ readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@~1.0.31:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readdirp@^2.0.0:
   version "2.1.0"
@@ -3895,8 +3911,8 @@ remove-trailing-separator@^1.0.1:
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
 
 repeat-element@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
 
 repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
@@ -4001,11 +4017,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-rxjs@^5.5.2:
-  version "5.5.11"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+rxjs@^6.1.0:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.1.tgz#878a1a8c64b8a5da11dcf74b5033fe944cdafb84"
   dependencies:
-    symbol-observable "1.0.1"
+    tslib "^1.9.0"
 
 safe-buffer@5.1.1:
   version "5.1.1"
@@ -4021,21 +4037,21 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sax@0.5.x:
   version "0.5.8"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
+  resolved "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
 
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 send@0.16.2:
   version "0.16.2"
@@ -4108,9 +4124,9 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shelljs@^0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+shelljs@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -4212,17 +4228,17 @@ source-map@0.1.x:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.6.0, source-map@~0.6.1:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -4322,12 +4338,16 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.1.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -4361,6 +4381,10 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
 strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -4376,7 +4400,7 @@ stylus@0.54.5, stylus@~0.54.5:
     sax "0.5.x"
     source-map "0.1.x"
 
-supports-color@5.4.0, supports-color@^5.3.0:
+supports-color@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
@@ -4392,17 +4416,19 @@ supports-color@^3.1.0:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  dependencies:
+    has-flag "^3.0.0"
+
 "sylvester@>= 0.0.12", "sylvester@>= 0.0.8":
   version "0.0.21"
   resolved "https://registry.yarnpkg.com/sylvester/-/sylvester-0.0.21.tgz#2987b1ce2bd2f38b0dce2a34388884bfa4400ea7"
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-
 table@^4.0.3:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
+  resolved "http://registry.npmjs.org/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
   dependencies:
     ajv "^6.0.1"
     ajv-keywords "^3.0.0"
@@ -4416,8 +4442,8 @@ taffydb@2.6.2:
   resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
 
 tar@^4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
   dependencies:
     chownr "^1.0.1"
     fs-minipass "^1.2.5"
@@ -4430,6 +4456,13 @@ tar@^4:
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+through2@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
 
 through@^2.3.6:
   version "2.3.8"
@@ -4495,6 +4528,10 @@ tough-cookie@^2.3.3, tough-cookie@~2.4.3:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -4597,7 +4634,7 @@ upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
-uri-js@^4.2.1:
+uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:
@@ -4628,8 +4665,8 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 validate-npm-package-license@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
@@ -4664,6 +4701,10 @@ vue-eslint-parser@^2.0.3:
 which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
 which@^1.0.9, which@^1.1.1, which@^1.2.9:
   version "1.3.1"
@@ -4706,7 +4747,7 @@ wordwrap@~0.0.2:
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  resolved "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
@@ -4724,6 +4765,10 @@ write@^0.2.1:
 xmlcreate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-1.0.2.tgz#fa6bf762a60a413fb3dd8f4b03c5b269238d308f"
+
+xtend@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
 y18n@^3.2.1:
   version "3.2.1"
@@ -4743,6 +4788,29 @@ yargs-parser@^2.4.1:
   dependencies:
     camelcase "^3.0.0"
     lodash.assign "^4.0.6"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^4.0.0:
   version "4.8.1"


### PR DESCRIPTION
Move @types modules to dependencies
According to https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/declaration%20files/Publishing.md#dependencies

Update comments to use primitive data types instead of non-primitive ones.
According to this: https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/declaration%20files/Do's%20and%20Don'ts.md#number-string-boolean-and-object